### PR TITLE
Utility functions for JSON data access

### DIFF
--- a/util.ml
+++ b/util.ml
@@ -1,0 +1,86 @@
+exception Type_error of string * json
+
+let typeof = function
+  | `Assoc _ -> "object"
+  | `Bool _ -> "bool"
+  | `Float _ -> "float"
+  | `Int _ -> "int"
+  | `List _ -> "array"
+  | `Null -> "null"
+  | `String _ -> "string"
+
+let typerr msg js = raise (Type_error (msg ^ typeof js, js))
+
+exception Undefined of string * json
+
+let ( |> ) x f = f x
+
+let assoc name obj =
+  try List.assoc name obj
+  with Not_found -> `Null
+
+let member name = function
+  | `Assoc obj -> assoc name obj
+  | js -> typerr ("Can't get member '" ^ name ^ "' of non-object type ") js
+
+let index i = function
+  | `List l as js ->
+      let len = List.length l in
+      let wrapped_index = if i < 0 then len + i else i in
+      if wrapped_index < 0 || wrapped_index >= len then
+        raise (Undefined ("Index " ^ string_of_int i ^ " out of bounds", js))
+      else List.nth l wrapped_index
+  | js -> typerr ("Can't get index " ^ string_of_int i
+                 ^ " of non-array type ") js
+
+let map f = function
+  | `List l -> `List (List.map f l)
+  | js -> typerr "Can't map function over non-array type " js
+
+let to_assoc = function
+  | `Assoc obj -> obj
+  | js -> typerr "Expected object, got " js
+
+let to_bool = function
+  | `Bool b -> b
+  | js -> typerr "Expected bool, got " js
+
+let to_bool_option = function
+  | `Bool b -> Some b
+  | `Null -> None
+  | js -> typerr "Expected bool or null, got " js
+
+let to_float = function
+  | `Float f -> f
+  | js -> typerr "Expected float, got " js
+
+let to_float_option = function
+  | `Float f -> Some f
+  | `Null -> None
+  | js -> typerr "Expected float or null, got " js
+
+let to_int = function
+  | `Int i -> i
+  | js -> typerr "Expected int, got " js
+
+let to_int_option = function
+  | `Int i -> Some i
+  | `Null -> None
+  | js -> typerr "Expected int or null, got " js
+
+let to_list = function
+  | `List l -> l
+  | js -> typerr "Expected array, got " js
+
+let to_string = function
+  | `String s -> s
+  | js -> typerr "Expected string, got " js
+
+let to_string_option = function
+  | `String s -> Some s
+  | `Null -> None
+  | js -> typerr "Expected string or null, got " js
+
+let convert_each f = function
+  | `List l -> List.map f l
+  | js -> typerr "Can't convert each element of non-array type " js

--- a/util.mli
+++ b/util.mli
@@ -1,0 +1,44 @@
+(** {2 Utility functions for data access} *)
+
+(** Raised when the JSON value is not of the correct type to support an
+    operation, e.g. [member] on an [`Int]. The string message explains the
+    mismatch. *)
+exception Type_error of string * json
+
+(** Raised when the equivalent JavaScript operation on the JSON value would
+    return undefined. Currently this only happens when an array index is out
+    of bounds. *)
+exception Undefined of string * json
+
+(** Forward pipe operator; useful for composing JSON access functions
+    without too many parentheses *)
+val ( |> ) : 'a -> ('a -> 'b) -> 'b
+
+(** [member k obj] returns the value associated with the key [k] in the JSON
+object [obj], or [`Null] if [k] is not present in [obj]. *)
+val member : string -> json -> json
+
+(** [index i arr] returns the value at index [i] in the JSON array [arr].
+    Negative indices count from the end of the list (so -1 is the last
+    element). *)
+val index : int -> json -> json
+
+(** [map f arr] calls the function [f] on each element of the JSON array
+    [arr], and returns a JSON array containing the results. *)
+val map : (json -> json) -> json -> json
+
+val to_assoc : json -> (string * json) list
+val to_bool : json -> bool
+val to_bool_option : json -> bool option
+val to_float : json -> float
+val to_float_option : json -> float option
+val to_int : json -> int
+val to_int_option : json -> int option
+val to_list : json -> json list
+val to_string : json -> string
+val to_string_option : json -> string option
+
+(** The conversion functions above cannot be used with [map], because they do
+    not return JSON values. This convenience function [convert_each to_f arr]
+    is equivalent to [List.map to_f (to_list arr)]. *)
+val convert_each : (json -> 'a) -> json -> 'a list

--- a/yojson.ml.cppo
+++ b/yojson.ml.cppo
@@ -36,6 +36,7 @@ struct
 #include "write.ml"
 #include "write2.ml"
 #include "read.ml"
+#include "util.ml"
 #undef INT
 #undef FLOAT
 #undef STRING

--- a/yojson.mli.cppo
+++ b/yojson.mli.cppo
@@ -46,6 +46,7 @@ sig
 #include "write.mli"
 #include "write2.mli"
 #include "read.mli"
+#include "util.mli"
 #undef INT
 #undef FLOAT
 #undef STRING


### PR DESCRIPTION
Enables path expressions, e.g.:
  Yojson.Basic.(profile
                 |> member "friends"
                 |> index 0
                 |> member "addresses"
                 |> map (member "zip_code")
                 |> convert_each to_int
               )
to get all the ZIP codes where my first friend has lived
