### PR TITLE
Make @NathanReb the new default codeowner.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,6 @@
-# We're looking for one or more volunteers to take the lead of yojson,
-# with the help of ocaml-community.
-#
-# Call for volunteers: https://github.com/ocaml-community/meta/issues/28
-# About ocaml-community: https://github.com/ocaml-community/meta
-#
-# Interim maintainers who won't be very responsive :-(
-* @mjambon @pmetzger
+# This file helps Github suggest reviewers of pull requests based on which
+# files changed.
+# Learn more at https://help.github.com/articles/about-codeowners/
+
+# The lead maintainer(s)
+* @NathanReb


### PR DESCRIPTION
@NathanReb needs to be made a project member first (see https://github.com/ocaml-community/yojson/issues/68).