### PR TITLE
Reduce macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,5 @@ env:
   - OCAML_VERSION=4.05
   - OCAML_VERSION=4.06
   - OCAML_VERSION=4.07
-matrix:
-  exclude:
-    - os: osx
-      env: OCAML_VERSION=4.02 OCAML_SWITCH=4.02.3
-    - os: osx
-      env: OCAML_VERSION=4.03
-    - os: osx
-      env: OCAML_VERSION=4.04
-    - os: osx
-      env: OCAML_VERSION=4.05
-    - os: osx
-      env: OCAML_VERSION=4.06
 os:
   - linux
-  - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,18 @@ env:
   - OCAML_VERSION=4.05
   - OCAML_VERSION=4.06
   - OCAML_VERSION=4.07
+matrix:
+  exclude:
+    - os: osx
+      env: OCAML_VERSION=4.02 OCAML_SWITCH=4.02.3
+    - os: osx
+      env: OCAML_VERSION=4.03
+    - os: osx
+      env: OCAML_VERSION=4.04
+    - os: osx
+      env: OCAML_VERSION=4.05
+    - os: osx
+      env: OCAML_VERSION=4.06
 os:
   - linux
   - osx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Yojson: low-level JSON library for OCaml
 ========================================
 
+[![Build Status](https://travis-ci.org/ocaml-community/yojson.svg?branch=master)](https://travis-ci.org/ocaml-community/yojson)
+
 _This library is for manipulating the json AST directly. For mapping between OCaml types and json, we recommend [atdgen](https://github.com/mjambon/atd)._
 
 Library documentation


### PR DESCRIPTION
As noticed, building on macOS takes forever and getting all the variations to build is 2h+ of waiting. Therefore I decided to exclude all but the newest OCaml for builds.

There is the questions whether it should not be enough to just test 4.02 and 4.07 on the Linux side since versions in between should just work, but these builds happen all faster than a single build on macOS.