### PR TITLE
Revert deprecation warning on `json` type aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### Fix
+
+- Revert the deprecation warning on `json` type aliases
+
 ## 1.7.0
 
 *2019-02-14*

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -53,7 +53,7 @@ All possible cases defined in Yojson:
 	    Syntax: [<"Foo">] or [<"Bar":123>].
 *)
 
-type json = t [@@deprecated "json types are being renamed and will be removed in the next Yojson major version. Use type t instead"]
+type json = t 
 (**
  * Compatibility type alias for type `t`
  *)


### PR DESCRIPTION
This has been causing troubles all around with no actual benefit.