### PR TITLE
Avoid full copy of buffer in reading json

### DIFF
--- a/lib/read.mll
+++ b/lib/read.mll
@@ -317,7 +317,7 @@ and finish_string v = parse
 
 and map_string v f = parse
     '"'           { let b = v.buf in
-                    f (Bytes.to_string b.Bi_outbuf.o_s) 0 b.Bi_outbuf.o_len }
+                    f (Bytes.sub_string b.Bi_outbuf.o_s 0 b.Bi_outbuf.o_len) 0 b.Bi_outbuf.o_len }
   | '\\'          { finish_escaped_char v lexbuf;
                     map_string v f lexbuf }
   | [^ '"' '\\']+ { add_lexeme v.buf lexbuf;


### PR DESCRIPTION
`map_string` copies the full buffer (`b.Bi_outbuf.o_s`) with calling `Bytes.to_string`.

* The size of buffer seems to increase consistently during the reading, which makes the copies expensive, especially when there has been a long-length field data. 
* But the function `f` is using only a substring of the buffer.

This PR tries to copy less in `map_string` with `Bytes.sub_string`.