### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/yojson.opam
+++ b/yojson.opam
@@ -12,7 +12,7 @@ build: [
 run-test: [["dune" "runtest" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build}
+  "dune"
   "cppo" {build}
   "easy-format"
   "biniou" {>= "1.2.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.