### PR TITLE
Discussion / Draft: Support trailing commas for JSON parsing

### DIFF
--- a/lib/read.mll
+++ b/lib/read.mll
@@ -231,20 +231,16 @@ rule read_json v = parse
                    try
                      read_space v lexbuf;
                      read_object_end lexbuf;
-                     let field_name = read_ident v lexbuf in
-                     read_space v lexbuf;
-                     read_colon v lexbuf;
-                     read_space v lexbuf;
-                     acc := (field_name, read_json v lexbuf) :: !acc;
                      while true do
-                       read_space v lexbuf;
-                       read_object_sep v lexbuf;
-                       read_space v lexbuf;
                        let field_name = read_ident v lexbuf in
                        read_space v lexbuf;
                        read_colon v lexbuf;
                        read_space v lexbuf;
                        acc := (field_name, read_json v lexbuf) :: !acc;
+                       read_space v lexbuf;
+                       read_object_sep v lexbuf;
+                       read_space v lexbuf;
+                       read_object_end lexbuf;
                      done;
                      assert false
                    with End_of_object ->
@@ -255,12 +251,12 @@ rule read_json v = parse
                    try
                      read_space v lexbuf;
                      read_array_end lexbuf;
-                     acc := read_json v lexbuf :: !acc;
                      while true do
+                       acc := read_json v lexbuf :: !acc;
                        read_space v lexbuf;
                        read_array_sep v lexbuf;
                        read_space v lexbuf;
-                       acc := read_json v lexbuf :: !acc;
+                       read_array_end lexbuf;
                      done;
                      assert false
                    with End_of_array ->
@@ -676,20 +672,16 @@ and read_abstract_fields read_key read_field init_acc v = parse
                try
                  read_space v lexbuf;
                  read_object_end lexbuf;
-                 let field_name = read_key v lexbuf in
-                 read_space v lexbuf;
-                 read_colon v lexbuf;
-                 read_space v lexbuf;
-                 acc := read_field !acc field_name v lexbuf;
                  while true do
-                   read_space v lexbuf;
-                   read_object_sep v lexbuf;
-                   read_space v lexbuf;
                    let field_name = read_key v lexbuf in
                    read_space v lexbuf;
                    read_colon v lexbuf;
                    read_space v lexbuf;
                    acc := read_field !acc field_name v lexbuf;
+                   read_space v lexbuf;
+                   read_object_sep v lexbuf;
+                   read_space v lexbuf;
+                   read_object_end lexbuf;
                  done;
                  assert false
                with End_of_object ->
@@ -761,20 +753,15 @@ and skip_json v = parse
   | '{'          { try
                      read_space v lexbuf;
                      read_object_end lexbuf;
-                     skip_ident v lexbuf;
-                     read_space v lexbuf;
-                     read_colon v lexbuf;
-                     read_space v lexbuf;
-                     skip_json v lexbuf;
                      while true do
-                       read_space v lexbuf;
-                       read_object_sep v lexbuf;
                        read_space v lexbuf;
                        skip_ident v lexbuf;
                        read_space v lexbuf;
                        read_colon v lexbuf;
                        read_space v lexbuf;
                        skip_json v lexbuf;
+                       read_space v lexbuf;
+                       read_object_sep v lexbuf;
                      done;
                      assert false
                    with End_of_object ->
@@ -784,12 +771,12 @@ and skip_json v = parse
   | '['          { try
                      read_space v lexbuf;
                      read_array_end lexbuf;
-                     skip_json v lexbuf;
                      while true do
+                       skip_json v lexbuf;
                        read_space v lexbuf;
                        read_array_sep v lexbuf;
                        read_space v lexbuf;
-                       skip_json v lexbuf;
+                       read_array_end lexbuf;
                      done;
                      assert false
                    with End_of_array ->


### PR DESCRIPTION
Hi,

Thanks for all the work on `yojson! I've been using it in a ton of projects - it's great 🎉 

I'm using it to parse user-crafted configuration files, and in those cases, I'd like more 'resiliency' - forgiving of comments and trailing commas. A use case for this is here: https://github.com/onivim/oni2/issues/836

I know this is likely the implementation is likely incorrect - it looks like the preference for this was to fulfill the RFC 8259 spec: https://github.com/onivim/oni2/issues/836 and this change breaks some of the currently-passing RFC 8259 compliances tests, as the RFC doesn't support trailing commas. 

Based on the details in #81 , it sounds like there is still some thought about where a resilient-parser like this would belong (ie, `Yojson.Standard.t` for RFC 8259 standards compliant parsing, and some other module - maybe `Yojson.Safe.t` or `Yojson.Resilient.t`?)

In any case, I wanted to put it up here as a draft in case there was anyone else looking for this-
