### PR TITLE
Remove no longer needed template file.

### DIFF
--- a/META.yojson.template
+++ b/META.yojson.template
@@ -1,6 +1,0 @@
-# JBUILDER_GEN
-
-package "biniou" (
-  description = "Deprecated. The yojson package already includes this"
-  requires = "yojson"
-)


### PR DESCRIPTION
I stumbled upon some problems with the latest version due to this file. With this file the `dune-package` generated was wrong and looked like this:

````
(lang dune 2.0)
(use_meta)
(version 17dc47d)
````

And compiling [ppx_yojson_conv](https://github.com/janestreet/ppx_yojson_conv) failed with the error message :

````
File "<lib>/yojson/dune-package", line 3, characters 1-8:
3 | (version 17dc47d)
     ^^^^^^^
Error: Unknown field version
````