### PR TITLE
Enable caching of OPAM directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: c
 sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
+cache:
+    directories:
+    - $HOME/.opam
 env:
   global:
   - PACKAGE=yojson


### PR DESCRIPTION
I got this trick from @lukepalmer, and it has sped up the builds of my project significantly. On my branch it took about 9-14 minutes per compiler to build the code, after rerunning the branch it took 2-7 minutes to build, which in my book is a significant life quality improvement.