### PR TITLE
Fix URL of atdgen/atd in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Yojson: low-level JSON library for OCaml
 
 [![Build Status](https://travis-ci.org/ocaml-community/yojson.svg?branch=master)](https://travis-ci.org/ocaml-community/yojson)
 
-_This library is for manipulating the json AST directly. For mapping between OCaml types and json, we recommend [atdgen](https://github.com/mjambon/atd)._
+_This library is for manipulating the json AST directly. For mapping between OCaml types and json, we recommend [atdgen](https://github.com/ahrefs/atd)._
 
 Library documentation
 ---------------------

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -2,7 +2,7 @@
    This module provides combinators for extracting fields from JSON
    values. This approach is recommended for reading a few fields
    from data returned by public APIs. However for more complex applications
-   we recommend {{:https://github.com/MyLifeLabs/atdgen}Atdgen}.
+   we recommend {{:https://github.com/ahrefs/atd}Atdgen}.
 
    Here is some sample JSON data:
 {v


### PR DESCRIPTION
This fixes the links to `atd`/`atdgen` to the current canonical location.