### PR TITLE
Remove `json` type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
   * `to_outbuf` becomes `to_buffer` and `stream_to_outbuf` becomes
     `stream_to_buffer`
 - Removed `yojson-biniou` library
+- Removed deprecated `json` type aliasing type `t` which has been available
+  since 1.6.0 (@Leonidas-from-XIV, #100).
 
 ### Fix
 

--- a/lib/dune
+++ b/lib/dune
@@ -23,7 +23,6 @@
    write.mli
    read.mli
    safe.mli
-   pretty.mli
    write2.mli
    common.mli
    util.mli

--- a/lib/pretty.mli
+++ b/lib/pretty.mli
@@ -1,3 +1,0 @@
-val pp : ?std:bool -> Format.formatter -> json -> unit
-val to_string : ?std:bool -> json -> string
-val to_channel : ?std:bool -> out_channel -> json -> unit

--- a/lib/type.ml
+++ b/lib/type.ml
@@ -53,11 +53,6 @@ All possible cases defined in Yojson:
 	    Syntax: [<"Foo">] or [<"Bar":123>].
 *)
 
-type json = t 
-(**
- * Compatibility type alias for type `t`
- *)
-
 (*
   Note to adventurers: ocamldoc does not support inline comments
   on each polymorphic variant, and cppo doesn't allow to concatenate


### PR DESCRIPTION
I've also chose to remove `json_max`. A quick search on GitHub has not shown any usage of it (mind you, the search is very bad, so I possibly missed something).

Closes #97.