### PR TITLE
Remove deprecated |> operator

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -16,8 +16,6 @@ let typerr msg js = raise (Type_error (msg ^ typeof js, js))
 
 exception Undefined of string * t
 
-let ( |> ) = ( |> )
-
 let assoc name obj =
   try List.assoc name obj
   with Not_found -> `Null

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -68,10 +68,6 @@ exception Undefined of string * t
       return undefined. Currently this only happens when an array index is out
       of bounds. *)
 
-val ( |> ) : 'a -> ('a -> 'b) -> 'b
-(** @deprecated Forward pipe operator; useful for composing JSON
-    access functions without too many parentheses *)
-
 val keys : t -> string list
   (** Returns all the key names in the given JSON object *)
 


### PR DESCRIPTION
This is available since 4.01 and we support 4.02+ so it is natively available in every supported version. And was already deprecated before.

Since we're doing a 2.0.0 release, we might as well just drop it while at it. The impact is absolutely minimal since this operator would be used via `open` and if it is not in the module it will instead refer to the `|>` operator in `Pervasives`/`Stdlib`/`Core`. I don't expect any real code to be affected by this change.