### PR TITLE
Remove `json_max` type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 - Removed `yojson-biniou` library
 - Removed deprecated `json` type aliasing type `t` which has been available
   since 1.6.0 (@Leonidas-from-XIV, #100).
+- Removed `json_max` type (@Leonidas-from-XIV, #103)
 - Removed constraint that the "root" value being rendered (via either
   `pretty_print` or `to_string`) must be an object or array. (@cemerick, #121)
 

--- a/lib/pretty.ml
+++ b/lib/pretty.ml
@@ -50,7 +50,7 @@ let rec format std (out:Format.formatter) (x:t) : unit =
         if std then
 #ifdef STRING
           let representation = `String s in
-#else
+#elif defined STRINGLIT
           let representation = `Stringlit s in
 #endif
           format std out representation
@@ -61,7 +61,7 @@ let rec format std (out:Format.formatter) (x:t) : unit =
         if std then
 #ifdef STRING
           let representation = `String s in
-#else
+#elif defined STRINGLIT
           let representation = `Stringlit s in
 #endif
           format std out (`List [ representation; x ])

--- a/lib/pretty.ml
+++ b/lib/pretty.ml
@@ -3,26 +3,39 @@ let pp_list sep ppx out l =
   let pp_sep out () = Format.fprintf out "%s@ " sep in
   Format.pp_print_list ~pp_sep ppx out l
 
-let rec format std (out:Format.formatter) (x : t) : unit =
+let rec format std (out:Format.formatter) (x:t) : unit =
   match x with
     | `Null -> Format.pp_print_string out "null"
     | `Bool x -> Format.pp_print_bool out x
+#ifdef INT
     | `Int x -> Format.pp_print_string out (json_string_of_int x)
+#endif
+#ifdef FLOAT
     | `Float x ->
         let s =
           if std then std_json_string_of_float x
           else json_string_of_float x
         in
         Format.pp_print_string out s
+#endif
+#ifdef STRING
     | `String s -> Format.pp_print_string out (json_string_of_string s)
-    | `Intlit s
-    | `Floatlit s
+#endif
+#ifdef INTLIT
+    | `Intlit s -> Format.pp_print_string out s
+#endif
+#ifdef FLOATLIT
+    | `Floatlit s -> Format.pp_print_string out s
+#endif
+#ifdef STRINGLIT
     | `Stringlit s -> Format.pp_print_string out s
+#endif
     | `List [] -> Format.pp_print_string out "[]"
     | `List l -> Format.fprintf out "[@;<1 0>@[<hov>%a@]@;<1 -2>]" (pp_list "," (format std)) l
     | `Assoc [] -> Format.pp_print_string out "{}"
     | `Assoc l ->
       Format.fprintf out "{@;<1 0>%a@;<1 -2>}" (pp_list "," (format_field std)) l
+#ifdef TUPLE
     | `Tuple l ->
         if std then
           format std out (`List l)
@@ -31,19 +44,31 @@ let rec format std (out:Format.formatter) (x : t) : unit =
             Format.pp_print_string out "()"
           else
             Format.fprintf out "(@,%a@;<0 -2>)" (pp_list "," (format std)) l
-
+#endif
+#ifdef VARIANT
     | `Variant (s, None) ->
         if std then
-          format std out (`String s)
+#ifdef STRING
+          let representation = `String s in
+#else
+          let representation = `Stringlit s in
+#endif
+          format std out representation
         else
           Format.fprintf out "<%s>" (json_string_of_string s)
 
     | `Variant (s, Some x) ->
         if std then
-          format std out (`List [ `String s; x ])
+#ifdef STRING
+          let representation = `String s in
+#else
+          let representation = `Stringlit s in
+#endif
+          format std out (`List [ representation; x ])
         else
           let op = json_string_of_string s in
           Format.fprintf out "<@[<hv2>%s: %a@]>" op (format std) x
+#endif
 
 and format_field std out (name, x) =
   Format.fprintf out "@[<hv2>%s: %a@]" (json_string_of_string name) (format std) x

--- a/lib/write2.ml
+++ b/lib/write2.ml
@@ -1,9 +1,9 @@
 
-let pretty_print ?std out (x : t) =
-  Pretty.pp ?std out (x :> json_max)
+let pretty_print ?std out x =
+  Pretty.pp ?std out x
 
-let pretty_to_string ?std (x : t) =
-  Pretty.to_string ?std (x :> json_max)
+let pretty_to_string ?std x =
+  Pretty.to_string ?std x
 
-let pretty_to_channel ?std oc (x : t) =
-  Pretty.to_channel ?std oc (x :> json_max)
+let pretty_to_channel ?std oc x =
+  Pretty.to_channel ?std oc x

--- a/lib/yojson.cppo.ml
+++ b/lib/yojson.cppo.ml
@@ -9,7 +9,6 @@
 #define TUPLE
 #define VARIANT
 #include "type.ml"
-type json_max = t
 #include "write.ml"
 #include "monomorphic.ml"
 module Pretty =
@@ -33,6 +32,10 @@ struct
 #define STRING
 #include "type.ml"
 #include "write.ml"
+module Pretty =
+struct
+#include "pretty.ml"
+end
 #include "monomorphic.ml"
 #include "write2.ml"
 #include "read.ml"
@@ -56,6 +59,10 @@ struct
 #include "type.ml"
 #include "safe.ml"
 #include "write.ml"
+module Pretty =
+struct
+#include "pretty.ml"
+end
 #include "monomorphic.ml"
 #include "write2.ml"
 #include "read.ml"
@@ -80,6 +87,10 @@ struct
 #define VARIANT
 #include "type.ml"
 #include "write.ml"
+module Pretty =
+struct
+#include "pretty.ml"
+end
 #include "monomorphic.ml"
 #include "write2.ml"
 #include "read.ml"

--- a/lib/yojson.cppo.mli
+++ b/lib/yojson.cppo.mli
@@ -132,7 +132,6 @@ end
 #define VARIANT
 #include "type.ml"
 #include "monomorphic.mli"
-type json_max = t
 #include "write.mli"
 #include "write2.mli"
 #undef INT


### PR DESCRIPTION
While removing `json` I came across `json_max` and wondered what that is for. So when I deleted it, I figured out it works this way:

- There is a top-level `Yojson` module which has a type `t`, that contains all the variants.
- That module has another module, `Yojson.Pretty` which has the prettyprinter for the "biggest" type.
- All the `Yojson.{Basic,Safe,Raw}` variants upcast their `t` type to this biggest type and and then use the functions from `Yojson.Pretty`.
- (Amusingly, it is therefore possible to get a `` `String`` in a variant that does not define `STRING` on the CPPO level, since it always uses `` `String`` instead of `` `Stringlit``, though this is mostly a weird behaviour and probably not a bug)

This PR changes it in a way that every of the variants has its own `Pretty` module which is specialized to only pretty-print the specific variant.

I've made this a separate PR since I would like to know your input:

  * The code is in my opinion somewhat easier to understand since all the different variants (`Basic`, `Safe`, `Raw` use their own `Pretty` module.
  * Potentially faster, since the pattern match is smaller, but I'd be surprised if it makes a nontrivial difference
  * The generated code is larger since `Pretty` exists 4 times now instead of once.

This is separated into its separate PR since I don't want to press it on the one that is important for the 2.0.0 release.

(Note this PR is branched off #100)