### PR TITLE
Avoid full buffer copy in `map_lexeme`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@
 - The function `to_file` now adds a newline at the end of the generated file. An
   optional argument allows to return to the original behaviour (#124, @panglesd)
 
+### Fix
+
+- Avoid copying unnecessarily large amounts of strings when parsing (#85, #108,
+  @Leonidas-from-XIV)
+
 ## 1.7.0
 
 *2019-02-14*

--- a/lib/read.mll
+++ b/lib/read.mll
@@ -151,7 +151,7 @@
 
   let map_lexeme f lexbuf =
     let len = lexbuf.lex_curr_pos - lexbuf.lex_start_pos in
-    f (Bytes.to_string lexbuf.lex_buffer) lexbuf.lex_start_pos len
+    f (Bytes.sub_string lexbuf.lex_buffer lexbuf.lex_start_pos len) lexbuf.lex_start_pos len
 
   type variant_kind = [ `Edgy_bracket | `Square_bracket | `Double_quote ]
   type tuple_kind = [ `Parenthesis | `Square_bracket ]


### PR DESCRIPTION
As mentioned in #85 by @skcho, the code in `map_ident`/`map_string` was changed to not copy the whole buffer and give a start/end point (though this happened somewhat more on the accidental than deliberate side) thus subtly changing the semantics of the data `f` was called on. This saves copying but prevents `f` from peeking beyond the borders it was
assigned. Whether this breaks consumers depends on what they do with it.

Nevertheless, what this PR does is it applies the same logic to `map_lexeme`, so while the semantics might have changed at least they change in a consistent way.

Closes #85