### PR TITLE
Run changelog action against `master` branch

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,7 +2,7 @@ name: Changelog check
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 jobs:


### PR DESCRIPTION
This is currently the branch that this repo uses as default.