### PR TITLE
Remove entry from changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,6 @@
 - Removed deprecated `json` type aliasing type `t` which has been available
   since 1.6.0 (@Leonidas-from-XIV, #100).
 
-### Fix
-
-- Revert the deprecation warning on `json` type aliases
-
 ## 1.7.0
 
 *2019-02-14*


### PR DESCRIPTION
This happened but afterwards the type got removed altogether and the change was never released so mentioning it it the changelog is more confusing than helpful.