### PR TITLE
remove restriction against generating JSON with an atomic root value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 - Removed `yojson-biniou` library
 - Removed deprecated `json` type aliasing type `t` which has been available
   since 1.6.0 (@Leonidas-from-XIV, #100).
+- Removed constraint that the "root" value being rendered (via either
+  `pretty_print` or `to_string`) must be an object or array. (@cemerick, #121)
 
 ### Add
 

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -72,13 +72,6 @@ let code_of_surrogate_pair i j =
 let utf8_of_surrogate_pair buf i j =
   utf8_of_code buf (code_of_surrogate_pair i j)
 
-let is_object_or_array x =
-  match x with
-      `List _
-    | `Assoc _ -> true
-    | _ -> false
-
-
 type lexer_state = {
   buf : Buffer.t;
     (* Buffer used to accumulate substrings *)

--- a/lib/pretty.ml
+++ b/lib/pretty.ml
@@ -49,11 +49,7 @@ and format_field std out (name, x) =
   Format.fprintf out "@[<hv2>%s: %a@]" (json_string_of_string name) (format std) x
 
 let pp ?(std = false) out x =
-  if std && not (is_object_or_array x) then
-    json_error
-      "Root is not an object or array as requested by the JSON standard"
-  else
-    Format.fprintf out "@[<hv2>%a@]" (format std) (x :> t)
+  Format.fprintf out "@[<hv2>%a@]" (format std) (x :> t)
 
 let to_string ?std x =
   Format.asprintf "%a" (pp ?std) x

--- a/lib/write.ml
+++ b/lib/write.ml
@@ -418,12 +418,8 @@ and write_std_variant ob s o =
 
 
 let to_buffer ?(std = false) ob x =
-  if std then (
-    if not (is_object_or_array x) then
-      json_error "Root is not an object or array"
-    else
-      write_std_json ob x
-  )
+  if std then
+    write_std_json ob x
   else
     write_json ob x
 


### PR DESCRIPTION
This fixes #121.

Unfortunately no tests to add; as it stands, there's a only a single monolithic test for pretty-printing, and the simple change doesn't seem to warrant setting up a new harness.