### PR TITLE
Making `to_string` generate POSIX-compliant files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,11 @@
 - Add an opam package `yojson-bench` to deal with benchmarks dependency
   (@tmcgilchrist, #117)
 
+### Change
+
+- The function `to_file` now adds a newline at the end of the generated file. An
+  optional argument allows to return to the original behaviour (#124, @panglesd)
+
 ## 1.7.0
 
 *2019-02-14*

--- a/lib/write.ml
+++ b/lib/write.ml
@@ -460,10 +460,12 @@ let to_output ?buf ?(len=4096) ?std out x =
   out#output (Buffer.contents ob) 0 (Buffer.length ob);
   ()
 
-let to_file ?len ?std file x =
+let to_file ?len ?std ?(newline = true) file x =
   let oc = open_out file in
   try
     to_channel ?len ?std oc x;
+    if newline then
+      output_string oc "\n";
     close_out oc
   with e ->
     close_out_noerr oc;

--- a/lib/write.mli
+++ b/lib/write.mli
@@ -48,9 +48,12 @@ val to_output :
 val to_file :
   ?len:int ->
   ?std:bool ->
+  ?newline:bool ->
   string -> t -> unit
   (** Write a compact JSON value to a file.
-      See [to_string] for the role of the optional arguments. *)
+      See [to_string] for the role of the optional arguments.
+      @param newline whether to end the content of the file with a new line.
+      Optional parameter with value [true] by default. *)
 
 val to_buffer :
   ?std:bool ->

--- a/test/fixtures.ml
+++ b/test/fixtures.ml
@@ -19,3 +19,7 @@ let json_string =
   ^ {|"string":"string",|}
   ^ {|"list":[0,1,2]|}
   ^ "}"
+
+let json_string_newline =
+  json_string
+  ^ "\n"

--- a/test/fixtures.mli
+++ b/test/fixtures.mli
@@ -5,3 +5,6 @@ val json_value : Yojson.Safe.t
 
 (** A JSON string that must parse to [json_value] *)
 val json_string : string
+
+(** The same JSON string terminated with a newline *)
+val json_string_newline : string

--- a/test/test_write.ml
+++ b/test/test_write.ml
@@ -11,7 +11,7 @@ let to_file () =
     close_in ic;
     s
   in
-  Alcotest.(check string) __LOC__ Fixtures.json_string file_content;
+  Alcotest.(check string) __LOC__ (Fixtures.json_string ^ "\n") file_content;
   Sys.remove output_file
 
 let single_json = [

--- a/test/test_write.ml
+++ b/test/test_write.ml
@@ -2,17 +2,32 @@ let to_string () =
   Alcotest.(check string) __LOC__ Fixtures.json_string (Yojson.Safe.to_string Fixtures.json_value)
 
 let to_file () =
-  let output_file = Filename.temp_file "test_yojson_to_file" ".json" in
-  Yojson.Safe.to_file output_file Fixtures.json_value;
-  let file_content =
-    let ic = open_in output_file in
-    let length = in_channel_length ic in
-    let s = really_input_string ic length in
-    close_in ic;
-    s
+  let test ?newline () =
+    let output_file = Filename.temp_file "test_yojson_to_file" ".json" in
+    let correction = match newline with
+        | None ->
+          Yojson.Safe.to_file output_file Fixtures.json_value;
+          Fixtures.json_string_newline
+        | Some newline -> 
+          Yojson.Safe.to_file ~newline output_file Fixtures.json_value;
+          if newline then
+            Fixtures.json_string_newline
+          else
+            Fixtures.json_string
+    in
+    let file_content =
+      let ic = open_in output_file in
+      let length = in_channel_length ic in
+      let s = really_input_string ic length in
+      close_in ic;
+      s
+    in
+    Alcotest.(check string) __LOC__ correction file_content;
+    Sys.remove output_file
   in
-  Alcotest.(check string) __LOC__ (Fixtures.json_string ^ "\n") file_content;
-  Sys.remove output_file
+  test ();
+  test ~newline:true ();
+  test ~newline:false ()
 
 let single_json = [
   "to_string", `Quick, to_string;


### PR DESCRIPTION
The POSIX standard requires that text files end with new lines, see the POSIX definition of [text files](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_403) and [lines](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206), or this [stackoverflow answer](https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline/729795#729795).

This was requested in #109. 

To give the possibility to keep the old behaviour, this PR adds an optional boolean parameter `newline` to the function `to_string` to specify whether a newline should be added or not. 
The default value is `true`, which is a breaking change, but `2.0` is anyway a breaking release.