### PR TITLE
Switch badge to point to OCaml CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Yojson: JSON library for OCaml
 ==============================
 
-[![Build Status](https://travis-ci.org/ocaml-community/yojson.svg?branch=master)](https://travis-ci.org/ocaml-community/yojson)
+[![Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focaml-community%2Fyojson%2Fmaster&logo=ocaml)](https://ci.ocamllabs.io/github/ocaml-community/yojson)
 
 This library parses JSON data into a nested OCaml tree data structure.
 


### PR DESCRIPTION
The code is inspired by the identical badge from dune-release, adapting for the URLs and branch.