### PR TITLE
Improved the entry point of the documentation.

### DIFF
--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,2 @@
+(documentation
+ (package yojson))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,23 +1,18 @@
 {0 The [yojson] library}
 
 The Yojson library provides runtime functions for reading and writing JSON
-data from OCaml. It addresses a few shortcomings of its predecessor
-json-wheel and is about twice as fast (2.7x reading, 1.3x writing; results
-may vary).
+data from OCaml.
 The design goals of Yojson are the following:
-- Reducing inter-package dependencies by the use of polymorphic
-variants for the JSON tree type.
 - Allowing type-aware serializers/deserializers
 to read and write directly without going through a generic JSON tree,
 for efficiency purposes.
-Readers and writers of all JSON syntaxic elements are provided
-but are undocumented and meant to be used by generated OCaml code.
 - Distinguishing between ints and floats.
 - Providing optional extensions of the JSON syntax.
 These extensions include comments, arbitrary strings,
 optional quotes around field names, tuples and variants.
+- Eventually supporting the {{:https://json5.org}JSON5} standard
 
-See {{:<http://json.org> JSON specification}json specification}.
+See {{:http://json.org}JSON specification}.
 
 Author: Martin Jambon
 

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -10,7 +10,6 @@ for efficiency purposes.
 - Providing optional extensions of the JSON syntax.
 These extensions include comments, arbitrary strings,
 optional quotes around field names, tuples and variants.
-- Eventually supporting the {{:https://json5.org}JSON5} standard
 
 See {{:http://json.org}JSON specification}.
 

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,27 @@
+{0 The [yojson] library}
+
+The Yojson library provides runtime functions for reading and writing JSON
+data from OCaml. It addresses a few shortcomings of its predecessor
+json-wheel and is about twice as fast (2.7x reading, 1.3x writing; results
+may vary).
+The design goals of Yojson are the following:
+- Reducing inter-package dependencies by the use of polymorphic
+variants for the JSON tree type.
+- Allowing type-aware serializers/deserializers
+to read and write directly without going through a generic JSON tree,
+for efficiency purposes.
+Readers and writers of all JSON syntaxic elements are provided
+but are undocumented and meant to be used by generated OCaml code.
+- Distinguishing between ints and floats.
+- Providing optional extensions of the JSON syntax.
+These extensions include comments, arbitrary strings,
+optional quotes around field names, tuples and variants.
+
+See {{:<http://json.org> JSON specification}json specification}.
+
+Author: Martin Jambon
+
+{1 Entry point}
+
+The entry point of this library is the module {!yojson}.
+

--- a/lib/yojson.cppo.mli
+++ b/lib/yojson.cppo.mli
@@ -3,7 +3,7 @@
 
    - The {{!basic}Basic} JSON type,
    - The {{!safe}Safe} JSON type, a superset of JSON with safer support for integers,
-   - The {{!raw}Raw} JSON type, a superset of JSON, safer but less integrated with ocaml types.
+   - The {{!raw}Raw} JSON type, a superset of JSON, safer but less integrated with OCaml types.
 
 Each of these different types have their own module.
 

--- a/lib/yojson.cppo.mli
+++ b/lib/yojson.cppo.mli
@@ -1,30 +1,19 @@
 (**
-   The Yojson library provides runtime functions for reading and writing JSON
-   data from OCaml. It addresses a few shortcomings of its predecessor
-   json-wheel and is about twice as fast (2.7x reading, 1.3x writing; results
-   may vary).
-   The design goals of Yojson are the following:
-   - Reducing inter-package dependencies by the use of polymorphic
-   variants for the JSON tree type.
-   - Allowing type-aware serializers/deserializers 
-   to read and write directly without going through a generic JSON tree,
-   for efficiency purposes.
-   Readers and writers of all JSON syntaxic elements are provided
-   but are undocumented and meant to be used by generated OCaml code.
-   - Distinguishing between ints and floats.
-   - Providing optional extensions of the JSON syntax.
-   These extensions include comments, arbitrary strings,
-   optional quotes around field names, tuples and variants.
-   
-   @author Martin Jambon
-   @see <http://json.org> JSON specification
- *)
+   The Yojson library provides several types for representing JSON values, with different use cases.
+
+   - The {{!basic}Basic} JSON type,
+   - The {{!safe}Safe} JSON type, a superset of JSON with safer support for integers,
+   - The {{!raw}Raw} JSON type, a superset of JSON, safer but less integrated with ocaml types.
+
+Each of these different types have their own module.
+
+*)
 
 (** {1 Shared types and functions} *)
 
 #include "common.mli"
 
-(** {1 Basic JSON tree type} *)
+(** {1:basic Basic JSON tree type} *)
 
 module Basic :
 sig
@@ -55,7 +44,7 @@ end
 #undef STRING
 end
 
-(** {1 Multipurpose JSON tree type} *)
+(** {{1:safe} Multipurpose JSON tree type} *)
 
 module Safe :
 sig
@@ -123,7 +112,7 @@ sig
 #undef VARIANT
 end
 
-(** {1 Supertype of all JSON tree types} *)
+(** {1:raw Supertype of all JSON tree types} *)
 
 #define INT
 #define INTLIT


### PR DESCRIPTION
This PR adds an `index.mld` to improve the entry point of the documentation.

It allows to:
- Hide packages that we do not want to include in the doc (such as `yojson-bench`)
- Describe the library in a short page, without the details of the API.

I think that it solves #112 and #44.