### PR TITLE
Stream fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 
 - Avoid copying unnecessarily large amounts of strings when parsing (#85, #108,
   @Leonidas-from-XIV)
+- Fix `stream_to_file` (#133, @tcoopman and @gasche)
 
 ## 1.7.0
 

--- a/lib/write.ml
+++ b/lib/write.ml
@@ -489,8 +489,11 @@ let stream_to_channel ?buf ?(len=2096) ?std oc st =
         None -> Buffer.create len
       | Some ob -> ob
   in
-  stream_to_buffer ?std ob st;
-  Buffer.output_buffer oc ob
+  Stream.iter (fun json ->
+    to_buffer ?std ob json;
+    Buffer.output_buffer oc ob;
+    Buffer.clear ob;
+  ) st
 
 let stream_to_file ?len ?std file st =
   let oc = open_out file in

--- a/lib/write.ml
+++ b/lib/write.ml
@@ -489,7 +489,8 @@ let stream_to_channel ?buf ?(len=2096) ?std oc st =
         None -> Buffer.create len
       | Some ob -> ob
   in
-  stream_to_buffer ?std ob st
+  stream_to_buffer ?std ob st;
+  Buffer.output_buffer oc ob
 
 let stream_to_file ?len ?std file st =
   let oc = open_out file in

--- a/test/test_write.ml
+++ b/test/test_write.ml
@@ -29,7 +29,24 @@ let to_file () =
   test ~newline:true ();
   test ~newline:false ()
 
+let stream_to_file () =
+  let output_file = Filename.temp_file "test_yojson_stream_to_file" ".json" in
+  let data = [`String "foo"; `String "bar"] in
+  Yojson.Safe.stream_to_file output_file (Stream.of_list data);
+  let read_data =
+    let stream = Yojson.Safe.stream_from_file output_file in
+    let acc = ref [] in
+    Stream.iter (fun v -> acc := v :: !acc) stream;
+    List.rev !acc
+  in
+  Sys.remove output_file;
+  if data <> read_data then
+    (* TODO: it would be nice to use Alcotest.check,
+       but we don't have a 'testable' instance for JSON values. *)
+    Alcotest.fail "stream_{to,from}_file roundtrip failure"
+
 let single_json = [
   "to_string", `Quick, to_string;
   "to_file", `Quick, to_file;
+  "stream_to_file", `Quick, stream_to_file;
 ]


### PR DESCRIPTION
Fixing `stream_to_file` bugs reported by @tcoopman in https://github.com/ocaml-community/yojson/pull/131#issuecomment-1034114373. The first commit is a clear bugfix (without it, the function is completely broken; I think it has been since 931050073020064a2182e659fd8d09f8a7e8240f), the second is rather an improvement in behavior -- the memory usage of the `stream_to_{file,channel}` functions now corresponds to the size of the largest element in the stream, instead of the total size of all elements of the stream.