### PR TITLE
Add benchmark for running `to_channel` with a preallocated buffer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
 
 - Add an opam package `yojson-bench` to deal with benchmarks dependency
   (@tmcgilchrist, #117)
+- Add a benchmark to judge the respective performance of providing a buffer vs
+  letting Yojson create an internal (#134, @Leonidas-from-XIV)
 
 ### Change
 

--- a/bench/dune
+++ b/bench/dune
@@ -6,6 +6,15 @@
  (libraries yojson core_bench core))
 
 (alias
-  (name bench)
+  (name bench-generic)
   (deps bench.json)
-  (action (run ./bench.exe)))
+  (action (run ./bench.exe generic)))
+
+(alias
+  (name bench-buffer)
+  (deps bench.json)
+  (action (run ./bench.exe buffer)))
+
+(alias
+  (name bench)
+  (deps (alias bench-generic) (alias bench-buffer)))


### PR DESCRIPTION
Since I was curious myself how much of a difference it makes to provide a buffer instead of letting Yojson create one (cc @c-cube).

The results on current `master` are as follows:

```
Estimated testing time 20s (2 benchmarks x 10s). Change using '-quota'.
┌───────────────────────────────────┬──────────┬─────────┬────────────┬──────────┬────────────┐
│ Name                              │ Time/Run │ mWd/Run │   mjWd/Run │ Prom/Run │ Percentage │
├───────────────────────────────────┼──────────┼─────────┼────────────┼──────────┼────────────┤
│ JSON writing with internal buffer │ 594.23us │ 20.02kw │ 32_269.74w │    1.74w │    100.00% │
│ JSON writing with provided buffer │ 498.96us │ 20.02kw │     -3.90w │    0.70w │     83.97% │
└───────────────────────────────────┴──────────┴─────────┴────────────┴──────────┴────────────┘
```

While touching the code, `Core_bench` supports comparing two different implementations so I split the benchmark apart into multiple subcommands. It is probably sensible run different test-runs with a "fresh" runtime instead of running everything in the same runtime, hence each run starts the test binary from scratch.