### PR TITLE
Add validate_t

### DIFF
--- a/lib/read.mli
+++ b/lib/read.mli
@@ -261,11 +261,13 @@ val read_json : lexer_state -> Lexing.lexbuf -> t
 val skip_json : lexer_state -> Lexing.lexbuf -> unit
 val buffer_json : lexer_state -> Lexing.lexbuf -> unit
 
+val validate_t : 'path -> t -> 'error option
 val validate_json : 'path -> t -> 'error option
   (* always returns [None].
      Provided so that atdgen users can write:
 
        type t <ocaml module="Yojson.Safe"> = abstract
+       type json <ocaml module="Yojson.Safe"> = abstract
   *)
 
 (* end undocumented section *)

--- a/lib/read.mll
+++ b/lib/read.mll
@@ -1213,5 +1213,6 @@ and junk = parse
   let compact ?std s =
     to_string (from_string s)
 
-  let validate_json _path _value = None
+  let validate_t _path _value = None
+  let validate_json = validate_t
 }

--- a/test/test_read.ml
+++ b/test/test_read.ml
@@ -12,7 +12,12 @@ let from_file () =
   Alcotest.(check Testable.yojson) __LOC__ Fixtures.json_value (Yojson.Safe.from_file input_file);
   Sys.remove input_file
 
+let validate () =
+  Alcotest.(check ( option unit )) __LOC__ None (Yojson.Safe.validate_t () Fixtures.json_value);
+  Alcotest.(check ( option unit )) __LOC__ None (Yojson.Safe.validate_json () Fixtures.json_value)
+
 let single_json = [
   "from_string", `Quick, from_string;
   "from_file", `Quick, from_file;
+  "validate", `Quick, validate;
 ]


### PR DESCRIPTION
While experimenting with atdgen, I came across an edge case when trying validations and untypable JSON.

If I use the following, I get a build warning about deprecation of the `json` type.
```
type json <ocaml module="Yojson.Safe"> = abstract
```

If I add an explicit type (`t="t"`) to address the warning, compilation fails with `Unbound value Yojson.Safe.validate_t`, so this PR adds it. Since it appears that the `json` type is disappearing, I also made `validate_json` an alias to `validate_t` as the canonical definition.