### PR TITLE
Remove `validate_json`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
 - Removed `json_max` type (@Leonidas-from-XIV, #103)
 - Removed constraint that the "root" value being rendered (via either
   `pretty_print` or `to_string`) must be an object or array. (@cemerick, #121)
+- Removed `validate_json` as it only made sense if the type was called `json`.
+  (@Leonidas-from-XIV, #<PR_NUMBER>)
 
 ### Add
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
 - Removed constraint that the "root" value being rendered (via either
   `pretty_print` or `to_string`) must be an object or array. (@cemerick, #121)
 - Removed `validate_json` as it only made sense if the type was called `json`.
-  (@Leonidas-from-XIV, #<PR_NUMBER>)
+  (@Leonidas-from-XIV, #137)
 
 ### Add
 

--- a/lib/read.mli
+++ b/lib/read.mli
@@ -261,12 +261,5 @@ val read_json : lexer_state -> Lexing.lexbuf -> t
 val skip_json : lexer_state -> Lexing.lexbuf -> unit
 val buffer_json : lexer_state -> Lexing.lexbuf -> unit
 
-val validate_json : 'path -> t -> 'error option
-  (* always returns [None].
-     Provided so that atdgen users can write:
-
-       type t <ocaml module="Yojson.Safe"> = abstract
-  *)
-
 (* end undocumented section *)
 (**/**)

--- a/lib/read.mll
+++ b/lib/read.mll
@@ -1212,6 +1212,4 @@ and junk = parse
 
   let compact ?std s =
     to_string (from_string s)
-
-  let validate_json _path _value = None
 }


### PR DESCRIPTION
It doesn't do much and made only sense in atdgen when we used to have a `json` type. Now that the type doesn't exist it would require to be renamed into `validate_t` but such functionality doesn't seem to make sense to exist in Yojson, especially as it never does any validation to begin with.

This issue was brought up by @metanivek in #136 and my assumption is that if we're changing the API then this function has no reason to exist and validation should be done on the atdgen side.