### PR TITLE
Use `Command_unix` following the deprecation of `Command`

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -79,7 +79,7 @@ let main () =
     ("generic", generic);
     ("buffer", buffer)
   ]
-  |> Command.run
+  |> Command_unix.run
 
 let () =
   main ()

--- a/bench/dune
+++ b/bench/dune
@@ -3,7 +3,7 @@
  (package yojson-bench)
  (public_name yojson-bench)
  (flags (-safe-string))
- (libraries yojson core_bench core))
+ (libraries yojson core_bench core core_unix.command_unix))
 
 (alias
   (name bench-generic)

--- a/yojson-bench.opam
+++ b/yojson-bench.opam
@@ -7,11 +7,12 @@ dev-repo: "git+https://github.com/ocaml-community/yojson.git"
 doc: "https://ocaml-community.github.io/yojson/"
 license: "BSD-3-Clause"
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.08"}
   "yojson" {= version}
   "dune"
-  "core_bench" {>= "v0.11.0"}
-  "core" {>= "v0.11.0"}
+  "core_bench" {>= "v0.14.0"}
+  "core" {>= "v0.14.0"}
+  "core_unix" {>= "v0.14.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
In Core v0.15 `Command.run` is deprecated in favor of `Command_unix` to be able to split Unix parts into their separate packages. This means the code needs to adapt. Turns out v0.14 supports that already and since this is a benchmarking binary there isn't that much value in keeping it installable on large range of versions of Core.