### PR TITLE
Fix formatting bug in documentation

### DIFF
--- a/lib/yojson.cppo.mli
+++ b/lib/yojson.cppo.mli
@@ -44,7 +44,7 @@ end
 #undef STRING
 end
 
-(** {{1:safe} Multipurpose JSON tree type} *)
+(** {1:safe Multipurpose JSON tree type} *)
 
 module Safe :
 sig


### PR DESCRIPTION
I noticed that the heading for `safe` wasn't appearing correctly on the generated HTML, see https://ocaml-community.github.io/yojson/yojson/Yojson/index.html#basic.