### PR TITLE
`dune subst` should be only called when `dev`

### DIFF
--- a/yojson-bench.opam
+++ b/yojson-bench.opam
@@ -15,7 +15,7 @@ depends: [
   "core_unix" {>= "v0.14.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 synopsis: "Run Yojson benchmarks"

--- a/yojson.opam
+++ b/yojson.opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ocaml-community/yojson.git"
 doc: "https://ocaml-community.github.io/yojson/"
 license: "BSD-3-Clause"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}


### PR DESCRIPTION
This is according to the opam-repository linter.