### PR TITLE
Moving from core_bench to ocurrent/current_bench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ uninstall:
 .PHONY: bench
 bench:
 	@ dune build bench/bench.exe
-	@ dune build @bench-generic --force 2>&1 | tee /dev/stderr | dune exec bench/conversions.exe -- generic
-	@ dune build @bench-buffer --force 2>&1 | tee /dev/stderr | dune exec bench/conversions.exe -- buffer
+	@ dune build @bench-generic --force 2>&1 | dune exec bench/conversions.exe -- generic
+	@ dune build @bench-buffer --force 2>&1 | dune exec bench/conversions.exe -- buffer
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ uninstall:
 
 .PHONY: bench
 bench:
-	@dune build @bench --force
+	@ dune build bench/bench.exe
+	@ dune build @bench-generic --force 2>&1 | tee /dev/stderr | dune exec bench/conversions.exe -- generic
+	@ dune build @bench-buffer --force 2>&1 | tee /dev/stderr | dune exec bench/conversions.exe -- buffer
 
 .PHONY: clean
 clean:

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -1,28 +1,22 @@
 open Core
 open Core_bench
 
-let data =
-  In_channel.read_all "bench.json"
-
+let data = In_channel.read_all "bench.json"
 let yojson_data = Yojson.Safe.from_string data
 
 (* chosen by fair dice roll, guaranteed to be large *)
 let large = 10_000
 
-let large_int_assoc = 
-  let ints = List.init large ~f:(fun n ->
-   (string_of_int n, `Int n))
-  in
+let large_int_assoc =
+  let ints = List.init large ~f:(fun n -> (string_of_int n, `Int n)) in
   `Assoc ints
 
-let large_int_list = 
+let large_int_list =
   let ints = List.init large ~f:(fun n -> `Int n) in
   `List ints
 
 let large_string_list =
-  let strings = List.init large ~f:(fun n ->
-    `String (string_of_int n))
-  in
+  let strings = List.init large ~f:(fun n -> `String (string_of_int n)) in
   `List strings
 
 let streamable_string =
@@ -33,53 +27,49 @@ let streamable_string =
   Buffer.contents buf
 
 let generic =
-  Bench.make_command [
-    Bench.Test.create ~name:"JSON reading" (fun () ->
-      ignore (Yojson.Safe.from_string data));
-    Bench.Test.create ~name:"JSON writing" (fun () ->
-      ignore (Yojson.Safe.to_string yojson_data));
-    Bench.Test.create ~name:"JSON writing assoc" (fun () ->
-      ignore (Yojson.Safe.to_string large_int_assoc));
-    Bench.Test.create ~name:"JSON writing int list" (fun () ->
-      ignore (Yojson.Safe.to_string large_int_list));
-    Bench.Test.create ~name:"JSON writing string list" (fun () ->
-      ignore (Yojson.Safe.to_string large_string_list));
-    Bench.Test.create ~name:"JSON writing int list to channel" (fun () ->
-      Out_channel.with_file "/dev/null" ~f:(fun oc ->
-      ignore (Yojson.Safe.to_channel oc large_int_list)));
-    Bench.Test.create ~name:"JSON writing string list to channel" (fun () ->
-      Out_channel.with_file "/dev/null" ~f:(fun oc ->
-      ignore (Yojson.Safe.to_channel oc large_string_list)));
-    Bench.Test.create ~name:"JSON writing assoc to channel" (fun () ->
-      Out_channel.with_file "/dev/null" ~f:(fun oc ->
-      ignore (Yojson.Safe.to_channel oc large_int_assoc)));
-    begin
-      let buf = Buffer.create 1000 in
-      Bench.Test.create ~name:"JSON seq roundtrip" (fun () ->
-        let stream = Yojson.Safe.seq_from_string ~buf streamable_string in
-        ignore (Yojson.Safe.seq_to_string ~buf stream)
-      )
-    end;
-  ]
+  Bench.make_command
+    [
+      Bench.Test.create ~name:"JSON reading" (fun () ->
+          ignore (Yojson.Safe.from_string data));
+      Bench.Test.create ~name:"JSON writing" (fun () ->
+          ignore (Yojson.Safe.to_string yojson_data));
+      Bench.Test.create ~name:"JSON writing assoc" (fun () ->
+          ignore (Yojson.Safe.to_string large_int_assoc));
+      Bench.Test.create ~name:"JSON writing int list" (fun () ->
+          ignore (Yojson.Safe.to_string large_int_list));
+      Bench.Test.create ~name:"JSON writing string list" (fun () ->
+          ignore (Yojson.Safe.to_string large_string_list));
+      Bench.Test.create ~name:"JSON writing int list to channel" (fun () ->
+          Out_channel.with_file "/dev/null" ~f:(fun oc ->
+              ignore (Yojson.Safe.to_channel oc large_int_list)));
+      Bench.Test.create ~name:"JSON writing string list to channel" (fun () ->
+          Out_channel.with_file "/dev/null" ~f:(fun oc ->
+              ignore (Yojson.Safe.to_channel oc large_string_list)));
+      Bench.Test.create ~name:"JSON writing assoc to channel" (fun () ->
+          Out_channel.with_file "/dev/null" ~f:(fun oc ->
+              ignore (Yojson.Safe.to_channel oc large_int_assoc)));
+      (let buf = Buffer.create 1000 in
+       Bench.Test.create ~name:"JSON seq roundtrip" (fun () ->
+           let stream = Yojson.Safe.seq_from_string ~buf streamable_string in
+           ignore (Yojson.Safe.seq_to_string ~buf stream)));
+    ]
 
 let buffer =
   let buf = Buffer.create 4096 in
   let data = large_int_assoc in
-  Bench.make_command [
-    Bench.Test.create ~name:"JSON writing with internal buffer" (fun () ->
-      Out_channel.with_file "/dev/null" ~f:(fun oc ->
-        ignore (Yojson.Safe.to_channel oc data)));
-    Bench.Test.create ~name:"JSON writing with provided buffer" (fun () ->
-      Out_channel.with_file "/dev/null" ~f:(fun oc ->
-        ignore (Yojson.Safe.to_channel ~buf oc data)));
-  ]
+  Bench.make_command
+    [
+      Bench.Test.create ~name:"JSON writing with internal buffer" (fun () ->
+          Out_channel.with_file "/dev/null" ~f:(fun oc ->
+              ignore (Yojson.Safe.to_channel oc data)));
+      Bench.Test.create ~name:"JSON writing with provided buffer" (fun () ->
+          Out_channel.with_file "/dev/null" ~f:(fun oc ->
+              ignore (Yojson.Safe.to_channel ~buf oc data)));
+    ]
 
 let main () =
-  Command.group ~summary:"Benchmark" [
-    ("generic", generic);
-    ("buffer", buffer)
-  ]
+  Command.group ~summary:"Benchmark"
+    [ ("generic", generic); ("buffer", buffer) ]
   |> Command_unix.run
 
-let () =
-  main ()
+let () = main ()

--- a/bench/conversions.ml
+++ b/bench/conversions.ml
@@ -1,0 +1,16 @@
+open Core_bench_internals.Simplified_benchmark
+
+let input_results in_chan = Sexplib.Sexp.input_sexp in_chan |> Results.t_of_sexp
+
+let extract full_name results =
+  let open Result in
+  List.iter
+    (fun res ->
+      Format.printf
+        {|{"results": [{"name": "%s", "metrics": [{"name": "%s", "value": %f, "units": "%s"}]}]}@.|}
+        full_name res.full_benchmark_name res.time_per_run_nanos "ns")
+    results
+
+let () =
+  let full_name = Sys.argv.(1) in
+  input_results stdin |> extract full_name

--- a/bench/dune
+++ b/bench/dune
@@ -1,20 +1,35 @@
-(executable
- (name bench)
+(executables
+ (names bench conversions)
  (package yojson-bench)
- (public_name yojson-bench)
+ (public_names yojson-bench -)
  (flags (-safe-string))
- (libraries yojson core_bench core core_unix.command_unix))
+ (libraries
+  yojson
+  core_bench
+  core
+  core_unix.command_unix
+  core_bench.internals))
 
 (alias
-  (name bench-generic)
-  (deps bench.json)
-  (action (run ./bench.exe generic)))
+ (name bench-generic)
+ (package yojson-bench)
+ (deps
+  bench.json
+  (package yojson))
+ (action
+  (run ./bench.exe generic -sexp)))
 
 (alias
-  (name bench-buffer)
-  (deps bench.json)
-  (action (run ./bench.exe buffer)))
+ (name bench-buffer)
+ (package yojson-bench)
+ (deps
+  bench.json
+  (package yojson))
+ (action
+  (run ./bench.exe buffer -sexp)))
 
 (alias
-  (name bench)
-  (deps (alias bench-generic) (alias bench-buffer)))
+ (name bench)
+ (deps
+  (alias bench-generic)
+  (alias bench-buffer)))


### PR DESCRIPTION
Using `make bench` will produce results in json format, to be parsed by the github action of current_bench