### PR TITLE
Allow continuous benchmarking with current-bench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,8 @@ uninstall:
 
 .PHONY: bench
 bench:
-	@ dune build bench/bench.exe
-	@ dune build @bench-generic-sexp --force 2>&1 | dune exec bench/conversions.exe -- generic
-	@ dune build @bench-buffer-sexp --force 2>&1 | dune exec bench/conversions.exe -- buffer
+	@dune build --display=quiet @bench-generic-sexp --force
+	@dune build --display=quiet @bench-buffer-sexp --force
 
 .PHONY: bench-local
 bench-local:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ uninstall:
 
 .PHONY: bench
 bench:
+	@ dune build bench/bench.exe
+	@ dune build @bench-generic-sexp --force 2>&1 | dune exec bench/conversions.exe -- generic
+	@ dune build @bench-buffer-sexp --force 2>&1 | dune exec bench/conversions.exe -- buffer
+
+.PHONY: bench-local
+bench-local:
 	@dune build @bench --force
 
 .PHONY: clean

--- a/bench/conversions.ml
+++ b/bench/conversions.ml
@@ -1,0 +1,53 @@
+open Core_bench_internals.Simplified_benchmark
+
+let input_results in_chan = Sexplib.Sexp.input_sexp in_chan |> Results.t_of_sexp
+
+let metrics name value unit_name =
+  let open Yojson.Safe in
+  `Assoc
+    [
+      ("name", `String name);
+      ("value", `Float value);
+      ("units", `String unit_name);
+    ]
+
+let extract full_name results =
+  let open Result in
+  let open Yojson.Safe in
+  List.iter
+    (fun res ->
+      let json =
+        `Assoc
+          [
+            ( "results",
+              `List
+                [
+                  `Assoc
+                    [
+                      ("name", `String full_name);
+                      ( "metrics",
+                        `List
+                          [
+                            metrics
+                              (res.full_benchmark_name ^ " (time)")
+                              res.time_per_run_nanos "ns";
+                            metrics
+                              (res.full_benchmark_name ^ " (memory)/minor")
+                              res.minor_words_per_run
+                              "words";
+                            metrics
+                              (res.full_benchmark_name ^ " (memory)/major")
+                              res.major_words_per_run
+                              "words";
+                          ] );
+                    ];
+                ] );
+          ]
+      in
+      to_channel stdout json;
+      print_newline ())
+    results
+
+let () =
+  let full_name = Sys.argv.(1) in
+  input_results stdin |> extract full_name

--- a/bench/conversions.ml
+++ b/bench/conversions.ml
@@ -1,9 +1,9 @@
-open Core_bench_internals.Simplified_benchmark
+module SB = Core_bench_internals.Simplified_benchmark
 
-let input_results in_chan = Sexplib.Sexp.input_sexp in_chan |> Results.t_of_sexp
+let input_results in_chan =
+  Sexplib.Sexp.input_sexp in_chan |> SB.Results.t_of_sexp
 
 let metrics name value unit_name =
-  let open Yojson.Safe in
   `Assoc
     [
       ("name", `String name);
@@ -12,41 +12,34 @@ let metrics name value unit_name =
     ]
 
 let extract full_name results =
-  let open Result in
-  let open Yojson.Safe in
-  List.iter
-    (fun res ->
-      let json =
-        `Assoc
-          [
-            ( "results",
-              `List
-                [
-                  `Assoc
-                    [
-                      ("name", `String full_name);
-                      ( "metrics",
-                        `List
-                          [
-                            metrics
-                              (res.full_benchmark_name ^ " (time)")
-                              res.time_per_run_nanos "ns";
-                            metrics
-                              (res.full_benchmark_name ^ " (memory)/minor")
-                              res.minor_words_per_run
-                              "words";
-                            metrics
-                              (res.full_benchmark_name ^ " (memory)/major")
-                              res.major_words_per_run
-                              "words";
-                          ] );
-                    ];
-                ] );
-          ]
-      in
-      to_channel stdout json;
-      print_newline ())
-    results
+  results
+  |> List.map (fun (res : SB.Result.t) ->
+         `Assoc
+           [
+             ( "results",
+               `List
+                 [
+                   `Assoc
+                     [
+                       ("name", `String full_name);
+                       ( "metrics",
+                         `List
+                           [
+                             metrics
+                               (res.full_benchmark_name ^ " (time)")
+                               res.time_per_run_nanos "ns";
+                             metrics
+                               (res.full_benchmark_name ^ " (memory)/minor")
+                               res.minor_words_per_run "words";
+                             metrics
+                               (res.full_benchmark_name ^ " (memory)/major")
+                               res.major_words_per_run "words";
+                           ] );
+                     ];
+                 ] );
+           ])
+  |> List.to_seq
+  |> Yojson.Safe.seq_to_channel stdout
 
 let () =
   let full_name = Sys.argv.(1) in

--- a/bench/dune
+++ b/bench/dune
@@ -3,7 +3,7 @@
  (package yojson-bench)
  (public_names yojson-bench -)
  (flags (-safe-string))
- (libraries yojson core_bench core core_unix.command_unix core_bench.internals))
+ (libraries yojson core_bench core core_unix.command_unix core_bench.internals sexplib))
 
 (alias
   (name bench-generic)

--- a/bench/dune
+++ b/bench/dune
@@ -1,9 +1,9 @@
-(executable
- (name bench)
+(executables
+ (names bench conversions)
  (package yojson-bench)
- (public_name yojson-bench)
+ (public_names yojson-bench -)
  (flags (-safe-string))
- (libraries yojson core_bench core core_unix.command_unix))
+ (libraries yojson core_bench core core_unix.command_unix core_bench.internals))
 
 (alias
   (name bench-generic)
@@ -11,9 +11,19 @@
   (action (run ./bench.exe generic)))
 
 (alias
+  (name bench-generic-sexp)
+  (deps bench.json)
+  (action (run ./bench.exe generic -sexp)))
+
+(alias
   (name bench-buffer)
   (deps bench.json)
   (action (run ./bench.exe buffer)))
+
+(alias
+  (name bench-buffer-sexp)
+  (deps bench.json)
+  (action (run ./bench.exe buffer -sexp)))
 
 (alias
   (name bench)

--- a/bench/dune
+++ b/bench/dune
@@ -3,30 +3,39 @@
  (package yojson-bench)
  (public_names yojson-bench -)
  (flags (-safe-string))
- (libraries yojson core_bench core core_unix.command_unix core_bench.internals sexplib))
+ (libraries yojson core_bench core core_unix.command_unix
+   core_bench.internals sexplib))
 
 (rule
-  (alias bench-generic)
-  (deps bench.json)
-  (action (run ./bench.exe generic)))
+ (alias bench-generic)
+ (deps bench.json)
+ (action
+  (run ./bench.exe generic)))
 
 (rule
-  (alias bench-generic-sexp)
-  (deps bench.json)
-  (action (pipe-stdout (run ./bench.exe generic -sexp)
-                       (run ./conversions.exe -- generic))))
+ (alias bench-generic-sexp)
+ (deps bench.json)
+ (action
+  (pipe-stdout
+   (run ./bench.exe generic -sexp)
+   (run ./conversions.exe -- generic))))
 
 (rule
-  (alias bench-buffer)
-  (deps bench.json)
-  (action (run ./bench.exe buffer)))
+ (alias bench-buffer)
+ (deps bench.json)
+ (action
+  (run ./bench.exe buffer)))
 
 (rule
-  (alias bench-buffer-sexp)
-  (deps bench.json)
-  (action (pipe-stdout (run ./bench.exe buffer -sexp)
-                       (run ./conversions.exe -- buffer))))
+ (alias bench-buffer-sexp)
+ (deps bench.json)
+ (action
+  (pipe-stdout
+   (run ./bench.exe buffer -sexp)
+   (run ./conversions.exe -- buffer))))
 
 (alias
-  (name bench)
-  (deps (alias bench-generic) (alias bench-buffer)))
+ (name bench)
+ (deps
+  (alias bench-generic)
+  (alias bench-buffer)))

--- a/bench/dune
+++ b/bench/dune
@@ -5,25 +5,27 @@
  (flags (-safe-string))
  (libraries yojson core_bench core core_unix.command_unix core_bench.internals sexplib))
 
-(alias
-  (name bench-generic)
+(rule
+  (alias bench-generic)
   (deps bench.json)
   (action (run ./bench.exe generic)))
 
-(alias
-  (name bench-generic-sexp)
+(rule
+  (alias bench-generic-sexp)
   (deps bench.json)
-  (action (run ./bench.exe generic -sexp)))
+  (action (pipe-stdout (run ./bench.exe generic -sexp)
+                       (run ./conversions.exe -- generic))))
 
-(alias
-  (name bench-buffer)
+(rule
+  (alias bench-buffer)
   (deps bench.json)
   (action (run ./bench.exe buffer)))
 
-(alias
-  (name bench-buffer-sexp)
+(rule
+  (alias bench-buffer-sexp)
   (deps bench.json)
-  (action (run ./bench.exe buffer -sexp)))
+  (action (pipe-stdout (run ./bench.exe buffer -sexp)
+                       (run ./conversions.exe -- buffer))))
 
 (alias
   (name bench)

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.0)
+(lang dune 2.7)
 (name yojson)

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 2.7)
 (name yojson)
+(formatting (enabled_for dune))

--- a/lib/dune
+++ b/lib/dune
@@ -3,31 +3,33 @@
 (rule
  (targets yojson.ml)
  (deps
-   (:out yojson.cppo.ml)
-   monomorphic.ml
-   read.ml
-   write.ml
-   safe.ml
-   pretty.ml
-   write2.ml
-   common.ml
-   util.ml
-   type.ml)
-  (action (run cppo %{out} -o %{targets})))
+  (:out yojson.cppo.ml)
+  monomorphic.ml
+  read.ml
+  write.ml
+  safe.ml
+  pretty.ml
+  write2.ml
+  common.ml
+  util.ml
+  type.ml)
+ (action
+  (run cppo %{out} -o %{targets})))
 
 (rule
  (targets yojson.mli)
  (deps
-   (:out yojson.cppo.mli)
-   monomorphic.mli
-   write.mli
-   read.mli
-   safe.mli
-   write2.mli
-   common.mli
-   util.mli
-   type.ml)
- (action (run cppo %{out} -o %{targets})))
+  (:out yojson.cppo.mli)
+  monomorphic.mli
+  write.mli
+  read.mli
+  safe.mli
+  write2.mli
+  common.mli
+  util.mli
+  type.ml)
+ (action
+  (run cppo %{out} -o %{targets})))
 
 (library
  (name yojson)

--- a/test/compliance/dune
+++ b/test/compliance/dune
@@ -1,16 +1,11 @@
 (executable
-  (name test)
-  (libraries
-    alcotest
-    yojson
-  )
-)
+ (name test)
+ (libraries alcotest yojson))
 
 (rule
-  (alias compliance-tests)
-  (deps
-    (:test test.exe)
-    (glob_files test_cases/*)
-  )
-  (action (run %{test} --show-errors))
-)
+ (alias compliance-tests)
+ (deps
+  (:test test.exe)
+  (glob_files test_cases/*))
+ (action
+  (run %{test} --show-errors)))

--- a/test/compliance/dune
+++ b/test/compliance/dune
@@ -6,8 +6,8 @@
   )
 )
 
-(alias
-  (name compliance-tests)
+(rule
+  (alias compliance-tests)
   (deps
     (:test test.exe)
     (glob_files test_cases/*)

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
 (test
-  (name test)
-  (package yojson)
-  (libraries yojson alcotest))
+ (name test)
+ (package yojson)
+ (libraries yojson alcotest))

--- a/test/pretty/dune
+++ b/test/pretty/dune
@@ -3,17 +3,17 @@
  (libraries yojson))
 
 (rule
-  (deps ./sample.json)
-  (action
-    (with-stdout-to
-      test.output.json
-      (run ./test.exe))))
+ (deps ./sample.json)
+ (action
+  (with-stdout-to
+   test.output.json
+   (run ./test.exe))))
 
 (rule
-  (action
-    (with-stdout-to
-      atd.output.json
-      (run ./atd.exe))))
+ (action
+  (with-stdout-to
+   atd.output.json
+   (run ./atd.exe))))
 
 (rule
  (alias runtest)

--- a/test/pretty/dune
+++ b/test/pretty/dune
@@ -15,8 +15,8 @@
       atd.output.json
       (run ./atd.exe))))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action
   (progn
    (diff test.expected.json test.output.json)

--- a/yojson-bench.opam
+++ b/yojson-bench.opam
@@ -9,7 +9,7 @@ license: "BSD-3-Clause"
 depends: [
   "ocaml" {>= "4.08"}
   "yojson" {= version}
-  "dune"
+  "dune" {>= "2.7.0"}
   "core_bench" {>= "v0.15.0"}
   "core" {>= "v0.14.0"}
   "core_unix" {>= "v0.14.0"}

--- a/yojson-bench.opam
+++ b/yojson-bench.opam
@@ -10,9 +10,10 @@ depends: [
   "ocaml" {>= "4.08"}
   "yojson" {= version}
   "dune"
-  "core_bench" {>= "v0.14.0"}
+  "core_bench" {>= "v0.15.0"}
   "core" {>= "v0.14.0"}
   "core_unix" {>= "v0.14.0"}
+  "sexplib" {>= "v0.9.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/yojson.opam
+++ b/yojson.opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune"
+  "dune" {>= "2.7.0"}
   "cppo" {build}
   "alcotest" {with-test & >= "0.8.5"}
   "odoc" {with-doc}


### PR DESCRIPTION
Hey all,
This PR aims at using the Github application [current-bench](https://github.com/marketplace/ocaml-benchmarks) on yojson. All results are directly pulled from original benchmarks made using `Core_bench`, and none of that code has to change in the future.
Due to how current-bench works, I had to hijack the `make bench` rule in the Makefile, but the old box-printing command is still available at `make bench-local`.
To fully activate the gh app you'll need to install it on the github marketplace.