### PR TITLE
Remove `write_float_fast` and `write_std_float_fast`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 ### Removed
 
+- Removed undocumented and unused functions `write_float_fast` and
+  `write_std_float_fast` from `Yojson`, `Yojson.Basic` and `Yojson.Safe`
+  (@sim642, #149)
+
 ### Changed
 
 ### Fixed

--- a/lib/write.ml
+++ b/lib/write.ml
@@ -115,25 +115,9 @@ let float_needs_period s =
     false
 
 (*
-  Both write_float_fast and write_float guarantee
-  that a sufficient number of digits are printed in order to
-  allow reversibility.
-
-  The _fast version is faster but often produces unnecessarily long numbers.
+  Guarantees that a sufficient number of digits are printed in order to allow
+  reversibility.
 *)
-(* unused *)
-let write_float_fast ob x =
-  match classify_float x with
-    FP_nan ->
-      Buffer.add_string ob "NaN"
-  | FP_infinite ->
-      Buffer.add_string ob (if x > 0. then "Infinity" else "-Infinity")
-  | _ ->
-      let s = Printf.sprintf "%.17g" x in
-      Buffer.add_string ob s;
-      if float_needs_period s then
-        Buffer.add_string ob ".0"
-
 let write_float ob x =
   match classify_float x with
     FP_nan ->
@@ -191,23 +175,6 @@ let json_string_of_float x =
   write_float ob x;
   Buffer.contents ob
 
-
-(* unused *)
-let write_std_float_fast ob x =
-  match classify_float x with
-    FP_nan ->
-      json_error "NaN value not allowed in standard JSON"
-  | FP_infinite ->
-      json_error
-        (if x > 0. then
-           "Infinity value not allowed in standard JSON"
-         else
-           "-Infinity value not allowed in standard JSON")
-  | _ ->
-      let s = Printf.sprintf "%.17g" x in
-      Buffer.add_string ob s;
-      if float_needs_period s then
-        Buffer.add_string ob ".0"
 
 let write_std_float ob x =
   match classify_float x with

--- a/lib/write.mli
+++ b/lib/write.mli
@@ -124,8 +124,6 @@ val write_int : Buffer.t -> int -> unit
 #ifdef FLOAT
 val write_float : Buffer.t -> float -> unit
 val write_std_float : Buffer.t -> float -> unit
-val write_float_fast : Buffer.t -> float -> unit
-val write_std_float_fast : Buffer.t -> float -> unit
 val write_float_prec : int -> Buffer.t -> float -> unit
 val write_std_float_prec : int -> Buffer.t -> float -> unit
 #endif


### PR DESCRIPTION
Removes the two unused functions according to the discussion in https://github.com/ocaml-community/yojson/pull/148#discussion_r923138077.

Notably, they are in the interface, but hidden from documentation and according to [sherlocode](https://sherlocode.com/?q=write_float_fast) no opam package calls them. This is unlike `write_float_prec` and `write_std_float_prec`, which are used by atdgen.
I'm not sure of why the fast versions exist in the first place though. Could be considered related to #51, but that seems to concern another issue.

### TODO
- [x] Rebase after #148 is merged.