### PR TITLE
Fix out-of-bounds error in atdgen parsers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@
 
 ### Fixed
 
+- Fix out-of-bounds error occurring when parsing object field names
+  with atdgen parsers using `map_ident` or `map_lexeme` (@mjambon, #150)
+
 ## 2.0.1
 
 *2022-06-28*

--- a/lib/read.mll
+++ b/lib/read.mll
@@ -151,7 +151,7 @@
 
   let map_lexeme f lexbuf =
     let len = lexbuf.lex_curr_pos - lexbuf.lex_start_pos in
-    f (Bytes.sub_string lexbuf.lex_buffer lexbuf.lex_start_pos len) lexbuf.lex_start_pos len
+    f (Bytes.sub_string lexbuf.lex_buffer lexbuf.lex_start_pos len) 0 len
 
   type variant_kind = [ `Edgy_bracket | `Square_bracket | `Double_quote ]
   type tuple_kind = [ `Parenthesis | `Square_bracket ]

--- a/test/fixtures.ml
+++ b/test/fixtures.ml
@@ -20,6 +20,10 @@ let json_string =
   ^ {|"list":[0,1,2]|}
   ^ "}"
 
+let unquoted_json = {|{foo: null}|}
+
+let unquoted_value = `Assoc [("foo", `Null)]
+
 let json_string_newline =
   json_string
   ^ "\n"

--- a/test/fixtures.mli
+++ b/test/fixtures.mli
@@ -8,3 +8,6 @@ val json_string : string
 
 (** The same JSON string terminated with a newline *)
 val json_string_newline : string
+
+val unquoted_json : string
+val unquoted_value : Yojson.Safe.t

--- a/test/test_read.ml
+++ b/test/test_read.ml
@@ -12,7 +12,53 @@ let from_file () =
   Alcotest.(check Testable.yojson) __LOC__ Fixtures.json_value (Yojson.Safe.from_file input_file);
   Sys.remove input_file
 
+let unquoted_from_string () =
+  Alcotest.(check Testable.yojson)
+    __LOC__
+    Fixtures.unquoted_value
+    (Yojson.Safe.from_string Fixtures.unquoted_json)
+
+let unquoted_from_lexbuf () =
+  let lexbuf = Lexing.from_string "{foo: null, bar: null}" in
+  let lexer_state = Yojson.init_lexer () in
+
+  let ident_expected expectation reference start len =
+    let identifier = String.sub reference start len in
+    Alcotest.(check string)
+      (Format.asprintf "Reference %s start %d len %d matches %s" reference start len expectation)
+      expectation
+      identifier;
+    ()
+  in
+  let skip_over f =
+    f lexer_state lexbuf
+  in
+  let map_ident f =
+    Yojson.Safe.map_ident lexer_state f lexbuf
+  in
+
+  skip_over Yojson.Safe.read_lcurl;
+  map_ident (ident_expected "foo");
+  skip_over Yojson.Safe.read_colon;
+  skip_over Yojson.Safe.read_space;
+  skip_over Yojson.Safe.read_null;
+  skip_over Yojson.Safe.read_comma;
+  skip_over Yojson.Safe.read_space;
+  map_ident (ident_expected "bar");
+  skip_over Yojson.Safe.read_colon;
+  skip_over Yojson.Safe.read_space;
+  skip_over Yojson.Safe.read_null;
+
+  (match Yojson.Safe.read_object_end lexbuf with
+  | _ -> Alcotest.fail "Object end expected but did not happen"
+  | exception Yojson.End_of_object -> ());
+
+  (* successfully made it here, pass the test *)
+  ()
+
 let single_json = [
   "from_string", `Quick, from_string;
   "from_file", `Quick, from_file;
+  "unquoted_from_string", `Quick, unquoted_from_string;
+  "unquoted_from_lexbuf", `Quick, unquoted_from_lexbuf;
 ]

--- a/test/test_read.ml
+++ b/test/test_read.ml
@@ -19,13 +19,13 @@ let unquoted_from_string () =
     (Yojson.Safe.from_string Fixtures.unquoted_json)
 
 let unquoted_from_lexbuf () =
-  let lexbuf = Lexing.from_string "{foo: null, bar: null}" in
+  let lexbuf = Lexing.from_string {|{foo: null, bar: "hello"}|} in
   let lexer_state = Yojson.init_lexer () in
 
   let ident_expected expectation reference start len =
     let identifier = String.sub reference start len in
     Alcotest.(check string)
-      (Format.asprintf "Reference %s start %d len %d matches %s" reference start len expectation)
+      (Format.asprintf "Reference '%s' start %d len %d matches '%s'" reference start len expectation)
       expectation
       identifier;
     ()
@@ -33,9 +33,11 @@ let unquoted_from_lexbuf () =
   let skip_over f =
     f lexer_state lexbuf
   in
-  let map_ident f =
-    Yojson.Safe.map_ident lexer_state f lexbuf
+  let map_f mapper f =
+    mapper lexer_state f lexbuf
   in
+  let map_ident = map_f Yojson.Safe.map_ident in
+  let map_string = map_f Yojson.Safe.map_string in
 
   skip_over Yojson.Safe.read_lcurl;
   map_ident (ident_expected "foo");
@@ -47,7 +49,11 @@ let unquoted_from_lexbuf () =
   map_ident (ident_expected "bar");
   skip_over Yojson.Safe.read_colon;
   skip_over Yojson.Safe.read_space;
-  skip_over Yojson.Safe.read_null;
+
+  let variant = skip_over Yojson.Safe.start_any_variant in
+  Alcotest.(check Testable.variant_kind) "String starts with double quote" `Double_quote variant;
+
+  map_string (ident_expected "hello");
 
   (match Yojson.Safe.read_object_end lexbuf with
   | _ -> Alcotest.fail "Object end expected but did not happen"

--- a/test/test_read.ml
+++ b/test/test_read.ml
@@ -18,8 +18,8 @@ let unquoted_from_string () =
     Fixtures.unquoted_value
     (Yojson.Safe.from_string Fixtures.unquoted_json)
 
-let unquoted_from_lexbuf () =
-  let lexbuf = Lexing.from_string {|{foo: null, bar: "hello"}|} in
+let map_ident_and_string () =
+  let lexbuf = Lexing.from_string {|{foo:"hello"}|} in
   let lexer_state = Yojson.init_lexer () in
 
   let ident_expected expectation reference start len =
@@ -42,13 +42,6 @@ let unquoted_from_lexbuf () =
   skip_over Yojson.Safe.read_lcurl;
   map_ident (ident_expected "foo");
   skip_over Yojson.Safe.read_colon;
-  skip_over Yojson.Safe.read_space;
-  skip_over Yojson.Safe.read_null;
-  skip_over Yojson.Safe.read_comma;
-  skip_over Yojson.Safe.read_space;
-  map_ident (ident_expected "bar");
-  skip_over Yojson.Safe.read_colon;
-  skip_over Yojson.Safe.read_space;
 
   let variant = skip_over Yojson.Safe.start_any_variant in
   Alcotest.(check Testable.variant_kind) "String starts with double quote" `Double_quote variant;
@@ -64,5 +57,5 @@ let single_json = [
   "from_string", `Quick, from_string;
   "from_file", `Quick, from_file;
   "unquoted_from_string", `Quick, unquoted_from_string;
-  "unquoted_from_lexbuf", `Quick, unquoted_from_lexbuf;
+  "map_ident/map_string", `Quick, map_ident_and_string;
 ]

--- a/test/test_read.ml
+++ b/test/test_read.ml
@@ -55,12 +55,10 @@ let unquoted_from_lexbuf () =
 
   map_string (ident_expected "hello");
 
-  (match Yojson.Safe.read_object_end lexbuf with
-  | _ -> Alcotest.fail "Object end expected but did not happen"
-  | exception Yojson.End_of_object -> ());
-
-  (* successfully made it here, pass the test *)
-  ()
+  Alcotest.check_raises
+    "Reading } raises End_of_object"
+    Yojson.End_of_object
+    (fun () -> Yojson.Safe.read_object_end lexbuf)
 
 let single_json = [
   "from_string", `Quick, from_string;

--- a/test/testable.ml
+++ b/test/testable.ml
@@ -1,1 +1,15 @@
 let yojson = Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal
+
+let variant_kind_pp fmt = function
+  | `Edgy_bracket -> Format.fprintf fmt "`Edgy_bracket"
+  | `Square_bracket -> Format.fprintf fmt "`Square_bracket"
+  | `Double_quote -> Format.fprintf fmt "`Double_quote"
+
+let variant_kind_equal a b =
+  match a, b with
+  | `Edgy_bracket, `Edgy_bracket -> true
+  | `Square_bracket, `Square_bracket -> true
+  | `Double_quote, `Double_quote -> true
+  | _ -> false
+
+let variant_kind = Alcotest.testable variant_kind_pp variant_kind_equal

--- a/test/testable.mli
+++ b/test/testable.mli
@@ -1,1 +1,2 @@
 val yojson : Yojson.Safe.t Alcotest.testable
+val variant_kind : Yojson.Safe.variant_kind Alcotest.testable


### PR DESCRIPTION
When running `make test` in atd, which just switched to yojson 2.0.x, we get an out-of-bounds error on two unit tests:
```
$ make test
...
> [FAIL]        atdgen         34   test ambiguous record with json adapters.
  [FAIL]        atdgen         35   test wrapping of polymorphic types.
...
┌──────────────────────────────────────────────────────────────────────────────┐
│ [FAIL]        atdgen         34   test ambiguous record with json adapters.  │
└──────────────────────────────────────────────────────────────────────────────┘
[invalid] out-of-bounds substring position or length: string = "ambiguous", requested position = 1, requested length = 9
          Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
          Called from Dune__exe__Test_ambiguous_record_j.read_ambiguous.f in file "atdgen/test/test_ambiguous_record_j.ml", line 203, characters 12-156
          Called from Yojson.Safe.map_ident in file "lib/read.ml" (inlined), line 1977, characters 3-43
          Called from Dune__exe__Test_ambiguous_record_j.read_ambiguous in file "atdgen/test/test_ambiguous_record_j.ml", line 225, characters 14-42
          Called from Dune__exe__Test_atdgen_main.test_ambiguous_record in file "atdgen/test/test_atdgen_main.ml", line 579, characters 4-55
          Called from Alcotest_engine__Core.Make.protect_test.(fun) in file "src/alcotest-engine/core.ml", line 180, characters 17-23
          Called from Alcotest_engine__Monad.Identity.catch in file "src/alcotest-engine/monad.ml", line 24, characters 31-35
```

The problem occurs when parsing unquoted JSON fields, which are supported as an extension of JSON. I believe I fixed the bug, but didn't add a unit test yet because I'm not sure yet where to put it.

To get the detailed error message above, check out https://github.com/ahrefs/atd/pull/310 and run `make test`.