### PR TITLE
Make `ocamlformat` ignore files using CPPO

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -4,3 +4,4 @@ lib/monomorphic.ml
 lib/write.ml*
 lib/pretty.ml
 lib/type.ml
+lib/util.ml


### PR DESCRIPTION
#163 created a CI failure, this should fix it.

(Hope to get rid of CPPO in the long term, but this is how it is for now)