### PR TITLE
Remove forward ref in the lexer

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
-(ocamllex read)
+(ocamllex read lexer_utils)
 
 (rule
  (targets t.ml)
@@ -111,7 +111,7 @@
 (library
  (name yojson)
  (public_name yojson)
- (modules yojson t basic safe raw common codec)
+ (modules yojson t basic safe raw common codec lexer_utils)
  (synopsis "JSON parsing and printing")
  (libraries seq)
  (flags

--- a/lib/lexer_utils.mll
+++ b/lib/lexer_utils.mll
@@ -1,0 +1,9 @@
+rule read_junk buf n = parse
+  | eof { () }
+  | _ {
+     if n <= 0 then ()
+     else begin
+       Buffer.add_char buf (Lexing.lexeme_char lexbuf 0);
+       read_junk buf (n - 1) lexbuf
+     end
+     }


### PR DESCRIPTION
The forward ref make jsoo deadcode elimination ineffective.

Fix #84 to some degree. 