### PR TITLE
Error printing tests

### DIFF
--- a/bin/ydump.ml
+++ b/bin/ydump.ml
@@ -1,5 +1,3 @@
-open Printf
-
 let license =
   "Copyright (c) 2010-2012 Martin Jambon\n\
    All rights reserved.\n\n\
@@ -41,10 +39,10 @@ let polycat write_one streaming in_file out_file =
     true
   with e ->
     finally ();
-    eprintf "Error:\n";
+    Printf.eprintf "Error:\n";
     (match e with
-    | Yojson.Json_error s -> eprintf "%s\n%!" s
-    | e -> eprintf "%s\n%!" (Printexc.to_string e));
+    | Yojson.Json_error s -> Printf.eprintf "%s\n%!" s
+    | e -> Printf.eprintf "%s\n%!" (Printexc.to_string e));
     false
 
 let cat sort output_biniou std compact streaming in_file out_file =
@@ -107,7 +105,7 @@ let parse_cmdline () =
   let files = ref [] in
   let anon_fun s = files := s :: !files in
   let msg =
-    sprintf
+    Printf.sprintf
       "JSON pretty-printer based on the Yojson library for OCaml\n\n\
        %s\n\n\
        JSON pretty-printer based on the Yojson library for OCaml\n\n\
@@ -119,7 +117,7 @@ let parse_cmdline () =
     | [] -> `Stdin
     | [ x ] -> `File x
     | _ ->
-        eprintf "Too many input files\n%!";
+        Printf.eprintf "Too many input files\n%!";
         exit 1
   in
   let out_file = match !out with None -> `Stdout | Some x -> `File x in

--- a/lib/lexer_utils.mll
+++ b/lib/lexer_utils.mll
@@ -10,7 +10,9 @@ rule read_junk buf n = parse
 
 {
 let read_junk_without_positions buf n (lexbuf : Lexing.lexbuf) =
-  let junk_start_pos = lexbuf.lex_start_pos in
+  let lex_abs_pos = lexbuf.lex_abs_pos in
+  let lex_start_pos = lexbuf.lex_start_pos in
   read_junk buf n lexbuf;
-  lexbuf.lex_start_pos <- junk_start_pos + 1
+  lexbuf.lex_start_pos <- lex_start_pos + 1;
+  lexbuf.lex_abs_pos <- lex_abs_pos
 }

--- a/lib/write.ml
+++ b/lib/write.ml
@@ -119,7 +119,7 @@ let write_float ob x =
         Buffer.add_string ob ".0"
 
 let write_normal_float_prec significant_figures ob x =
-  let open Printf in
+  let sprintf = Printf.sprintf in
   let s =
     match significant_figures with
         1 -> sprintf "%.1g" x

--- a/test/test_read.ml
+++ b/test/test_read.ml
@@ -3,10 +3,65 @@ let from_string () =
     __LOC__ Fixtures.json_value
     (Yojson.Safe.from_string Fixtures.json_string)
 
-let from_string_fail () =
+let parse s () = s |> Yojson.Safe.from_string |> ignore
+let parse_basic s () = s |> Yojson.Basic.from_string |> ignore
+
+let from_string_fail_simple () =
   Alcotest.check_raises "Location of parsing failure is correct"
-    (Yojson.Json_error "Line 1, bytes 0-5:\nInvalid token 'hello'") (fun () ->
-      Yojson.Safe.from_string "hello" |> ignore)
+    (Yojson.Json_error "Line 1, bytes 0-5:\nInvalid token 'hello'")
+    (parse "hello")
+
+let from_string_fail_lines () =
+  Alcotest.check_raises "Location of parsing failure has right line"
+    (Yojson.Json_error "Line 3, bytes 0-1:\nExpected ':' but found '}'")
+    (parse {|{
+      hello
+}|})
+
+let from_string_fail_bytes () =
+  Alcotest.check_raises "Location has right line and bytes"
+    (Yojson.Json_error
+       "Line 2, bytes 6-9:\nExpected string or identifier but found '3\n}'")
+    (parse {|{
+      3
+}|})
+
+let from_string_fail_unterminated () =
+  Alcotest.check_raises "Runaway string in toplevel"
+    (Yojson.Json_error "Line 1, bytes 12-13:\nUnexpected end of input")
+    (parse {|"unterminated|})
+
+let from_string_fail_nested_unterminated () =
+  Alcotest.check_raises "Runaway string in structure"
+    (Yojson.Json_error "Line 2, bytes 5-6:\nUnexpected end of input")
+    (parse {|[1,
+    "]|})
+
+let from_string_fail_unterminated_structure () =
+  Alcotest.check_raises "Array never closed"
+    (Yojson.Json_error "Line 1, bytes 0-1:\nUnexpected end of input")
+    (parse "[")
+
+let from_string_fail_unstarted_structure () =
+  Alcotest.check_raises "Array never opened"
+    (Yojson.Json_error "Line 1, bytes 0-1:\nInvalid token ']'") (parse "]")
+
+let from_string_fail_unstarted_object () =
+  Alcotest.check_raises "Object never opened"
+    (Yojson.Json_error "Line 1, bytes 0-1:\nInvalid token '}'") (parse "}")
+
+let from_string_fail_large_int () =
+  Alcotest.check_raises "Too large integer"
+    (* TODO: this location wrong, shouldn't be negative *)
+    (Yojson.Json_error
+       "Line 1, bytes -1-19:\nInt overflow '4611686018427387905'")
+    (* 2^62 + 1 *)
+    (parse_basic "4611686018427387905")
+
+let from_string_fail_escaped_char () =
+  Alcotest.check_raises "Invalid escape sequence"
+    (Yojson.Json_error "Line 1, bytes 2-4:\nInvalid escape sequence 'a\"'")
+    (parse {|"\a"|})
 
 let from_file () =
   let input_file = Filename.temp_file "test_yojson_from_file" ".json" in
@@ -56,7 +111,24 @@ let map_ident_and_string () =
 let single_json =
   [
     ("from_string", `Quick, from_string);
-    ("from_string_fail", `Quick, from_string_fail);
+    ("from_string_fail_simple", `Quick, from_string_fail_simple);
+    ("from_string_fail_lines", `Quick, from_string_fail_lines);
+    ("from_string_fail_bytes", `Quick, from_string_fail_bytes);
+    ("from_string_fail_unterminated", `Quick, from_string_fail_unterminated);
+    ( "from_string_fail_nested_unterminated",
+      `Quick,
+      from_string_fail_nested_unterminated );
+    ( "from_string_fail_unterminated_structure",
+      `Quick,
+      from_string_fail_unterminated_structure );
+    ( "from_string_fail_unstarted_structure",
+      `Quick,
+      from_string_fail_unstarted_structure );
+    ( "from_string_fail_unstarted_object",
+      `Quick,
+      from_string_fail_unstarted_object );
+    ("from_string_fail_large_int", `Quick, from_string_fail_large_int);
+    ("from_string_fail_escaped_char", `Quick, from_string_fail_escaped_char);
     ("from_file", `Quick, from_file);
     ("unquoted_from_string", `Quick, unquoted_from_string);
     ("map_ident/map_string", `Quick, map_ident_and_string);


### PR DESCRIPTION
This adds a few regression tests to make sure the printing of error location doesn't break when working on the code. One of the tests shows even that the printing is off and needs to be fixed, so I marked it that it is buggy (and might push a fix for it later, but I feel this is already useful as-is).