### PR TITLE
Add proper dependency from `yojson-five` to `yojson`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,7 @@ It supports parsing JSON5 to Yojson.Basic.t and Yojson.Safe.t types.")
   (depends
     (ocaml (>= 4.08))
     (sedlex (>= 2.5))
+    (yojson (= :version))
     (alcotest (and :with-test (>= 0.8.5)))))
 
 (package

--- a/yojson-five.opam
+++ b/yojson-five.opam
@@ -17,6 +17,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "sedlex" {>= "2.5"}
+  "yojson" {= version}
   "alcotest" {with-test & >= "0.8.5"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/25994 I realized that `yojson-five` does not depend on `yojson` in the OPAM metadata. This fixes the issue. The constraint on the version is technically speaking not necessary, but for keeping our own sanity in determining the version bounds it is easier to do it this way.