### PR TITLE
Add test for handling CRLF line endings

### DIFF
--- a/test/fixtures.ml
+++ b/test/fixtures.ml
@@ -11,12 +11,24 @@ let json_value =
       ("assoc", `Assoc [ ("value", `Int 42) ]);
     ]
 
-let json_string =
-  "{" ^ {|"null":null,|} ^ {|"bool":true,|} ^ {|"int":0,|}
-  ^ {|"intlit":10000000000000000000,|} ^ {|"float":0.0,|}
-  ^ {|"string":"string",|} ^ {|"list":[0,1,2],|} ^ {|"assoc":{"value":42}|}
-  ^ "}"
+let crlf = "\r\n"
 
+let snippets =
+  [
+    "{";
+    {|"null":null,|};
+    {|"bool":true,|};
+    {|"int":0,|};
+    {|"intlit":10000000000000000000,|};
+    {|"float":0.0,|};
+    {|"string":"string",|};
+    {|"list":[0,1,2],|};
+    {|"assoc":{"value":42}|};
+    "}";
+  ]
+
+let json_string = String.concat "" snippets
+let json_string_crlf = String.concat crlf snippets
 let unquoted_json = {|{foo: null}|}
 let unquoted_value = `Assoc [ ("foo", `Null) ]
 let json_string_newline = json_string ^ "\n"

--- a/test/fixtures.mli
+++ b/test/fixtures.mli
@@ -6,6 +6,9 @@ val json_value : Yojson.Safe.t
 val json_string : string
 (** A JSON string that must parse to [json_value] *)
 
+val json_string_crlf : string
+(** A JSON string separated by [\r\n] that must parse to [json_value] *)
+
 val json_string_newline : string
 (** The same JSON string terminated with a newline *)
 

--- a/test/test_read.ml
+++ b/test/test_read.ml
@@ -3,6 +3,11 @@ let from_string () =
     __LOC__ Fixtures.json_value
     (Yojson.Safe.from_string Fixtures.json_string)
 
+let from_crlf_string () =
+  Alcotest.(check Testable.yojson)
+    __LOC__ Fixtures.json_value
+    (Yojson.Safe.from_string Fixtures.json_string_crlf)
+
 let parse s () = s |> Yojson.Safe.from_string |> ignore
 let parse_basic s () = s |> Yojson.Basic.from_string |> ignore
 
@@ -111,6 +116,7 @@ let map_ident_and_string () =
 let single_json =
   [
     ("from_string", `Quick, from_string);
+    ("from_crlf_string", `Quick, from_crlf_string);
     ("from_string_fail_simple", `Quick, from_string_fail_simple);
     ("from_string_fail_lines", `Quick, from_string_fail_lines);
     ("from_string_fail_bytes", `Quick, from_string_fail_bytes);


### PR DESCRIPTION
It seems to work fine so this PR just adds a test that this is the case.

Closes #155