### PR TITLE
Use ocaml.org as documentation location

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -7,7 +7,6 @@
 
 (maintainers "paul-elliot@tarides.com" "nathan@tarides.com" "marek@tarides.com")
 (authors "Martin Jambon")
-(documentation "https://ocaml-community.github.io/yojson")
 
 (package
   (name yojson)
@@ -16,6 +15,7 @@
 
 ydump is a pretty-printing command-line program provided with the
 yojson package.")
+  (documentation "https://ocaml.org/p/yojson/latest")
   (depends
     (ocaml (>= 4.02.3))
     (alcotest (and :with-test (>= 0.8.5)))
@@ -26,6 +26,7 @@ yojson package.")
   (synopsis "Yojson-five is a parsing and printing library for the JSON5 format")
   (description "Yojson-five is a parsing and printing library for the JSON5 format.
 It supports parsing JSON5 to Yojson.Basic.t and Yojson.Safe.t types.")
+  (documentation "https://ocaml.org/p/yojson-five/latest")
   (depends
     (ocaml (>= 4.08))
     (sedlex (>= 2.5))

--- a/yojson-bench.opam
+++ b/yojson-bench.opam
@@ -11,7 +11,6 @@ maintainer: [
 authors: ["Martin Jambon"]
 license: "BSD-3-Clause"
 homepage: "https://github.com/ocaml-community/yojson"
-doc: "https://ocaml-community.github.io/yojson"
 bug-reports: "https://github.com/ocaml-community/yojson/issues"
 depends: [
   "dune" {>= "2.7"}

--- a/yojson-five.opam
+++ b/yojson-five.opam
@@ -11,7 +11,7 @@ maintainer: [
 authors: ["Martin Jambon"]
 license: "BSD-3-Clause"
 homepage: "https://github.com/ocaml-community/yojson"
-doc: "https://ocaml-community.github.io/yojson"
+doc: "https://ocaml.org/p/yojson-five/latest"
 bug-reports: "https://github.com/ocaml-community/yojson/issues"
 depends: [
   "dune" {>= "2.7"}

--- a/yojson.opam
+++ b/yojson.opam
@@ -13,7 +13,7 @@ maintainer: [
 authors: ["Martin Jambon"]
 license: "BSD-3-Clause"
 homepage: "https://github.com/ocaml-community/yojson"
-doc: "https://ocaml-community.github.io/yojson"
+doc: "https://ocaml.org/p/yojson/latest"
 bug-reports: "https://github.com/ocaml-community/yojson/issues"
 depends: [
   "dune" {>= "2.7"}


### PR DESCRIPTION
Instead of writing our own docs to github pages, pointing to ocaml.org is kind of nicer.