### PR TITLE
Improve the error messages displayed by the JSON5 lexer and parser.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 *2024-06-04*
 
+### Added
+
+- Add locations in the JSON5 parser error messages.
+
 ### Fixed
 
 - Don't expose `Yojson_five` internals anymore (@Leonidas_from_XIV, #180)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,12 @@
-## 2.2.1
-
-*2024-06-04*
+## unreleased
 
 ### Added
 
-- Add locations in the JSON5 parser error messages.
+- Add locations in the JSON5 parser error messages (@gcluzel, #182)
+
+## 2.2.1
+
+*2024-06-04*
 
 ### Fixed
 

--- a/lib/json5/errors.ml
+++ b/lib/json5/errors.ml
@@ -1,0 +1,4 @@
+let string_of_position { Lexing.pos_lnum; pos_fname; _ } =
+  match pos_fname with
+  | "" -> Printf.sprintf "Line %d" pos_lnum
+  | fname -> Printf.sprintf "File %s, line %d" fname pos_lnum

--- a/lib/json5/errors.mli
+++ b/lib/json5/errors.mli
@@ -1,0 +1,4 @@
+val string_of_position : Lexing.position -> string
+(** [string_of_position pos] returns a string that contains the line and, if
+  supplied, the filename of the position in a way that's appropriate to include
+  in an error message *)

--- a/lib/json5/lexer.ml
+++ b/lib/json5/lexer.ml
@@ -16,23 +16,30 @@ type token =
   | INT_OR_FLOAT of string
   | INT of string
   | STRING of string
+  | IDENTIFIER_NAME of string
   | EOF
 
-let pp_token ppf = function
-  | OPEN_PAREN -> Format.pp_print_string ppf "("
-  | CLOSE_PAREN -> Format.pp_print_string ppf ")"
-  | OPEN_BRACE -> Format.pp_print_string ppf "{"
-  | CLOSE_BRACE -> Format.pp_print_string ppf "}"
-  | OPEN_BRACKET -> Format.pp_print_string ppf "["
-  | CLOSE_BRACKET -> Format.pp_print_string ppf "]"
-  | COLON -> Format.pp_print_string ppf ":"
-  | COMMA -> Format.pp_print_string ppf ","
-  | TRUE -> Format.pp_print_string ppf "true"
-  | FALSE -> Format.pp_print_string ppf "false"
-  | NULL -> Format.pp_print_string ppf "null"
-  | FLOAT s | INT_OR_FLOAT s | INT s -> Format.pp_print_string ppf s
-  | STRING s -> Format.fprintf ppf "%S" s
-  | EOF -> Format.pp_print_string ppf "EOF"
+let pp_token ppf =
+  let ps = Format.pp_print_string ppf in
+  let pf = Format.fprintf ppf in
+  function
+  | OPEN_PAREN -> ps "'('"
+  | CLOSE_PAREN -> ps "')'"
+  | OPEN_BRACE -> ps "'{'"
+  | CLOSE_BRACE -> ps "'}'"
+  | OPEN_BRACKET -> ps "'['"
+  | CLOSE_BRACKET -> ps "']'"
+  | COLON -> ps "':'"
+  | COMMA -> ps "','"
+  | TRUE -> ps "'true'"
+  | FALSE -> ps "'false'"
+  | NULL -> ps "'null'"
+  | FLOAT s -> pf "FLOAT %S" s
+  | INT_OR_FLOAT s -> pf "INT_OR_STRING %S" s
+  | INT s -> pf "INT %S" s
+  | STRING s -> pf "%S" s
+  | IDENTIFIER_NAME s -> pf "IDENTIFIER_NAME %S" s
+  | EOF -> ps "EOF"
 
 let lexer_error lexbuf =
   let pos_start, _pos_end = Sedlexing.lexing_positions lexbuf in
@@ -246,6 +253,6 @@ let rec lex tokens buf =
       lex ((INT_OR_FLOAT s, pos) :: tokens) buf
   | identifier_name ->
       let s = lexeme buf in
-      lex ((STRING s, pos) :: tokens) buf
+      lex ((IDENTIFIER_NAME s, pos) :: tokens) buf
   | eof -> Ok (List.rev ((EOF, pos) :: tokens))
   | _ -> lexer_error buf

--- a/lib/json5/lexer.ml
+++ b/lib/json5/lexer.ml
@@ -214,9 +214,10 @@ let string_lex_double lexbuf strbuf =
 
 let string_lex lexbuf quote =
   let strbuf = Buffer.create 200 in
-  if quote = "'" then string_lex_single lexbuf strbuf
-  else if quote = {|"|} then string_lex_double lexbuf strbuf
-  else Error (Printf.sprintf "Invalid string quote %S" quote)
+  match quote with
+  | "'" -> string_lex_single lexbuf strbuf
+  | {|"|} -> string_lex_double lexbuf strbuf
+  | _ -> Error (Printf.sprintf "Invalid string quote %S" quote)
 
 let rec lex tokens buf =
   let lexeme = Sedlexing.Utf8.lexeme in

--- a/lib/json5/lexer.ml
+++ b/lib/json5/lexer.ml
@@ -35,14 +35,10 @@ let pp_token ppf = function
   | EOF -> Format.pp_print_string ppf "EOF"
 
 let lexer_error lexbuf =
-  let { Lexing.pos_fname = file; pos_lnum = line; _ }, _ =
-    Sedlexing.lexing_positions lexbuf
-  in
-  let file_line =
-    if String.equal file "" then "Line" else Printf.sprintf "File %s, line" file
-  in
+  let pos_start, _pos_end = Sedlexing.lexing_positions lexbuf in
+  let location = Errors.string_of_position pos_start in
   let msg =
-    Printf.sprintf "%s %d: Unexpected character '%s'" file_line line
+    Printf.sprintf "%s: Unexpected character '%s'" location
       (Sedlexing.Utf8.lexeme lexbuf)
   in
   Error msg

--- a/lib/json5/lexer.ml
+++ b/lib/json5/lexer.ml
@@ -9,7 +9,6 @@ type token =
   | CLOSE_BRACKET
   | COLON
   | COMMA
-  | COMMENT of string
   | TRUE
   | FALSE
   | NULL
@@ -17,26 +16,33 @@ type token =
   | INT_OR_FLOAT of string
   | INT of string
   | STRING of string
-  | IDENTIFIER_NAME of string
+  | EOF
 
 let pp_token ppf = function
-  | OPEN_PAREN -> Format.fprintf ppf "'('"
-  | CLOSE_PAREN -> Format.fprintf ppf "')'"
-  | OPEN_BRACE -> Format.fprintf ppf "'{'"
-  | CLOSE_BRACE -> Format.fprintf ppf "'}'"
-  | OPEN_BRACKET -> Format.fprintf ppf "'['"
-  | CLOSE_BRACKET -> Format.fprintf ppf "']'"
-  | COLON -> Format.fprintf ppf "':'"
-  | COMMA -> Format.fprintf ppf "','"
-  | COMMENT s -> Format.fprintf ppf "COMMENT '%s'" s
-  | TRUE -> Format.fprintf ppf "'true'"
-  | FALSE -> Format.fprintf ppf "'false'"
-  | NULL -> Format.fprintf ppf "'null'"
-  | FLOAT s -> Format.fprintf ppf "FLOAT '%s'" s
-  | INT_OR_FLOAT s -> Format.fprintf ppf "INT_OR_FLOAT '%s'" s
-  | INT s -> Format.fprintf ppf "INT '%s'" s
-  | STRING s -> Format.fprintf ppf "STRING '%s'" s
-  | IDENTIFIER_NAME s -> Format.fprintf ppf "IDENTIFIER_NAME '%s'" s
+  | OPEN_PAREN -> Format.pp_print_string ppf "("
+  | CLOSE_PAREN -> Format.pp_print_string ppf ")"
+  | OPEN_BRACE -> Format.pp_print_string ppf "{"
+  | CLOSE_BRACE -> Format.pp_print_string ppf "}"
+  | OPEN_BRACKET -> Format.pp_print_string ppf "["
+  | CLOSE_BRACKET -> Format.pp_print_string ppf "]"
+  | COLON -> Format.pp_print_string ppf ":"
+  | COMMA -> Format.pp_print_string ppf ","
+  | TRUE -> Format.pp_print_string ppf "true"
+  | FALSE -> Format.pp_print_string ppf "false"
+  | NULL -> Format.pp_print_string ppf "null"
+  | FLOAT s | INT_OR_FLOAT s | INT s -> Format.pp_print_string ppf s
+  | STRING s -> Format.fprintf ppf "%S" s
+  | EOF -> Format.pp_print_string ppf "eof"
+
+let custom_error lexbuf =
+  let { Lexing.pos_fname = file; pos_lnum = line; _ }, _ =
+    Sedlexing.lexing_positions lexbuf
+  in
+  let file_line =
+    if String.equal file "" then "Line" else Format.sprintf "File %s, line" file
+  in
+  Format.sprintf "%s %d: Unexpected character '%s'" file_line line
+    (Sedlexing.Utf8.lexeme lexbuf)
 
 let source_character = [%sedlex.regexp? any]
 let line_terminator = [%sedlex.regexp? 0x000A | 0x000D | 0x2028 | 0x2029]
@@ -182,10 +188,7 @@ let string_lex_single lexbuf strbuf =
     | Sub (source_character, ('\'' | line_terminator)) ->
         Buffer.add_string strbuf (lexeme lexbuf);
         lex lexbuf strbuf
-    | _ ->
-        lexeme lexbuf
-        |> Format.sprintf "Unexpected character: %s"
-        |> Result.error
+    | _ -> Error (custom_error lexbuf)
   in
   lex lexbuf strbuf
 
@@ -202,10 +205,7 @@ let string_lex_double lexbuf strbuf =
     | Sub (source_character, ('"' | line_terminator)) ->
         Buffer.add_string strbuf (lexeme lexbuf);
         lex lexbuf strbuf
-    | _ ->
-        lexeme lexbuf
-        |> Format.sprintf "Unexpected character: %s"
-        |> Result.error
+    | _ -> Error (custom_error lexbuf)
   in
   lex lexbuf strbuf
 
@@ -217,35 +217,35 @@ let string_lex lexbuf quote =
 
 let rec lex tokens buf =
   let lexeme = Sedlexing.Utf8.lexeme in
+  let pos, _ = Sedlexing.lexing_positions buf in
   match%sedlex buf with
-  | '(' -> lex (OPEN_PAREN :: tokens) buf
-  | ')' -> lex (CLOSE_PAREN :: tokens) buf
-  | '{' -> lex (OPEN_BRACE :: tokens) buf
-  | '}' -> lex (CLOSE_BRACE :: tokens) buf
-  | '[' -> lex (OPEN_BRACKET :: tokens) buf
-  | ']' -> lex (CLOSE_BRACKET :: tokens) buf
-  | ':' -> lex (COLON :: tokens) buf
-  | ',' -> lex (COMMA :: tokens) buf
+  | '(' -> lex ((OPEN_PAREN, pos) :: tokens) buf
+  | ')' -> lex ((CLOSE_PAREN, pos) :: tokens) buf
+  | '{' -> lex ((OPEN_BRACE, pos) :: tokens) buf
+  | '}' -> lex ((CLOSE_BRACE, pos) :: tokens) buf
+  | '[' -> lex ((OPEN_BRACKET, pos) :: tokens) buf
+  | ']' -> lex ((CLOSE_BRACKET, pos) :: tokens) buf
+  | ':' -> lex ((COLON, pos) :: tokens) buf
+  | ',' -> lex ((COMMA, pos) :: tokens) buf
   | Chars {|"'|} ->
       let* s = string_lex buf (lexeme buf) in
-      lex (STRING s :: tokens) buf
+      lex ((STRING s, pos) :: tokens) buf
   | multi_line_comment | single_line_comment | white_space | line_terminator ->
       lex tokens buf
-  | "true" -> lex (TRUE :: tokens) buf
-  | "false" -> lex (FALSE :: tokens) buf
-  | "null" -> lex (NULL :: tokens) buf
+  | "true" -> lex ((TRUE, pos) :: tokens) buf
+  | "false" -> lex ((FALSE, pos) :: tokens) buf
+  | "null" -> lex ((NULL, pos) :: tokens) buf
   | json5_float ->
       let s = lexeme buf in
-      lex (FLOAT s :: tokens) buf
+      lex ((FLOAT s, pos) :: tokens) buf
   | json5_int ->
       let s = lexeme buf in
-      lex (INT s :: tokens) buf
+      lex ((INT s, pos) :: tokens) buf
   | json5_int_or_float ->
       let s = lexeme buf in
-      lex (INT_OR_FLOAT s :: tokens) buf
+      lex ((INT_OR_FLOAT s, pos) :: tokens) buf
   | identifier_name ->
       let s = lexeme buf in
-      lex (IDENTIFIER_NAME s :: tokens) buf
-  | eof -> Ok (List.rev tokens)
-  | _ ->
-      lexeme buf |> Format.asprintf "Unexpected character: '%s'" |> Result.error
+      lex ((STRING s, pos) :: tokens) buf
+  | eof -> Ok (List.rev ((EOF, pos) :: tokens))
+  | _ -> Error (custom_error buf)

--- a/lib/json5/lexer.ml
+++ b/lib/json5/lexer.ml
@@ -32,7 +32,7 @@ let pp_token ppf = function
   | NULL -> Format.pp_print_string ppf "null"
   | FLOAT s | INT_OR_FLOAT s | INT s -> Format.pp_print_string ppf s
   | STRING s -> Format.fprintf ppf "%S" s
-  | EOF -> Format.pp_print_string ppf "eof"
+  | EOF -> Format.pp_print_string ppf "EOF"
 
 let lexer_error lexbuf =
   let { Lexing.pos_fname = file; pos_lnum = line; _ }, _ =

--- a/lib/json5/parser.ml
+++ b/lib/json5/parser.ml
@@ -28,7 +28,7 @@ and parse_assoc acc = function
   | [] -> Error "Unexpected end of input"
   | [ (Lexer.EOF, pos) ] -> parser_error pos "Unexpected end of input"
   | (CLOSE_BRACE, _) :: xs -> Ok (acc, xs)
-  | (STRING k, _) :: xs -> (
+  | (STRING k, _) :: xs | (IDENTIFIER_NAME k, _) :: xs -> (
       match xs with
       | [] -> Error "Unexpected end of input"
       | [ (Lexer.EOF, pos) ] -> parser_error pos "Unexpected end of input"
@@ -49,12 +49,13 @@ and parse_assoc acc = function
               parser_error pos s)
       | (x, pos) :: _ ->
           let s =
-            Format.asprintf "Expected ':' but found '%a'" Lexer.pp_token x
+            Format.asprintf "Expected %a but found %a" Lexer.pp_token
+              Lexer.COLON Lexer.pp_token x
           in
           parser_error pos s)
   | (x, pos) :: _ ->
       let s =
-        Format.asprintf "Expected string or identifier but found '%a'"
+        Format.asprintf "Expected string or identifier but found %a"
           Lexer.pp_token x
       in
       parser_error pos s

--- a/lib/json5/parser.ml
+++ b/lib/json5/parser.ml
@@ -1,11 +1,8 @@
 open Let_syntax.Result
 
 let parser_error pos error =
-  let file_line =
-    if String.equal pos.Lexing.pos_fname "" then "Line"
-    else Printf.sprintf "File %s, line" pos.Lexing.pos_fname
-  in
-  let msg = Printf.sprintf "%s %d: %s" file_line pos.Lexing.pos_lnum error in
+  let location = Errors.string_of_position pos in
+  let msg = Printf.sprintf "%s: %s" location error in
   Error msg
 
 let rec parse_list acc = function

--- a/test_json5/test.ml
+++ b/test_json5/test.ml
@@ -107,6 +107,8 @@ No \\n's!",
        expected);
     parsing_should_fail_with_error "unexpected EOF in list" "[1, 2,"
       "Line 1: Unexpected end of input";
+    parsing_should_fail_with_error "unexpected EOF on different line" "\n[1, 2,"
+      "Line 2: Unexpected end of input";
     parsing_should_fail_with_error "unexpected EOF in assoc" {|{"foo": 1,|}
       "Line 1: Unexpected end of input";
     parsing_should_fail_with_error "missing colon in assoc" {|{"foo"}|}

--- a/test_json5/test.ml
+++ b/test_json5/test.ml
@@ -1,25 +1,24 @@
 module M = Yojson_five.Safe
 
 let yojson = Alcotest.testable M.pp M.equal
-let equal_string = Alcotest.testable Fmt.string String.equal
 
 (* any error message will match the string. *)
-let ignore_string_content = Alcotest.testable Fmt.string (fun _ _ -> true)
+let any_string = Alcotest.testable Fmt.string (fun _ _ -> true)
 
-let parsing_test_case name expected input testable_str =
+let parsing_test_case name error_msg expected input =
   Alcotest.test_case name `Quick (fun () ->
-      Alcotest.(check (result yojson testable_str))
+      Alcotest.(check (result yojson error_msg))
         name expected (M.from_string input))
 
 let parsing_should_succeed name input expected =
-  parsing_test_case name (Ok expected) input equal_string
+  parsing_test_case name Alcotest.string (Ok expected) input
 
 let parsing_should_fail name input =
   let failure = Error "<anything>" in
-  parsing_test_case name failure input ignore_string_content
+  parsing_test_case name any_string failure input
 
 let parsing_should_fail_with_error name input expected =
-  parsing_test_case name (Error expected) input equal_string
+  parsing_test_case name Alcotest.string (Error expected) input
 
 let parsing_tests =
   [
@@ -106,9 +105,9 @@ No \\n's!",
   "backwardsCompatible": "with JSON",
 }|}
        expected);
-    parsing_should_fail_with_error "unexpected eof in list" "[1, 2,"
+    parsing_should_fail_with_error "unexpected EOF in list" "[1, 2,"
       "Line 1: Unexpected end of input";
-    parsing_should_fail_with_error "unexpected eof in assoc" {|{"foo": 1,|}
+    parsing_should_fail_with_error "unexpected EOF in assoc" {|{"foo": 1,|}
       "Line 1: Unexpected end of input";
     parsing_should_fail_with_error "missing colon in assoc" {|{"foo"}|}
       "Line 1: Expected ':' but found '}'";


### PR DESCRIPTION
Since JSON5 is a standard intended to parse JSON written by humans, it's a bit unfortunate that the error messages were not very descriptive.
I tried to make them closer to the ones displayed by the classic YoJson parser. Also, when it's available, the line where the error message is located is displayed.