### PR TITLE
Remove left-over mentions of tuple and variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
 - Removed support for Tuple and Variant in JSON. It was a non-standard
   extension that was rarely used, so this simplifies the Yojson types and the
-  parser more standard-conforming (#105, #158 @Leonidas-from-XIV)
+  parser more standard-conforming (#105, #158, #<PR_NUMBER> @Leonidas-from-XIV)
 
 ### Security
 

--- a/bin/ydump.ml
+++ b/bin/ydump.ml
@@ -73,8 +73,7 @@ let parse_cmdline () =
       ( "-std",
         Arg.Set std,
         "\n\
-        \          Convert tuples and variants into standard JSON,\n\
-        \          refuse to print NaN and infinities,\n\
+        \          Refuse to print NaN and infinities,\n\
         \          require the root node to be either an object or an array." );
       ( "-c",
         Arg.Set compact,

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -9,7 +9,7 @@ for efficiency purposes.
 - Distinguishing between ints and floats.
 - Providing optional extensions of the JSON syntax.
 These extensions include comments, arbitrary strings,
-optional quotes around field names, tuples and variants.
+optional quotes around field names.
 
 See {{:http://json.org}JSON specification}.
 

--- a/lib/basic.cppo.mli
+++ b/lib/basic.cppo.mli
@@ -1,6 +1,5 @@
 (**
-   This module supports standard JSON nodes only, i.e. no special syntax
-   for variants or tuples as supported by {!Yojson.Safe}.
+   This module supports standard JSON nodes only.
    Arbitrary integers are not supported as they must all fit within the
    standard OCaml int type (31 or 63 bits depending on the platform).
 

--- a/lib/prettyprint.ml
+++ b/lib/prettyprint.ml
@@ -43,13 +43,9 @@ let is_atom (x: [> t]) =
   | `Floatlit _
   | `Stringlit _
   | `List []
-  | `Assoc []
-  | `Tuple []
-  | `Variant (_, None) -> true
+  | `Assoc [] -> true
   | `List _
-  | `Assoc _
-  | `Tuple _
-  | `Variant (_, Some _) -> false
+  | `Assoc _ -> false
 
 let is_atom_list l =
   List.for_all is_atom l

--- a/lib/raw.cppo.ml
+++ b/lib/raw.cppo.ml
@@ -1,8 +1,6 @@
 #define INTLIT
 #define FLOATLIT
 #define STRINGLIT
-#define TUPLE
-#define VARIANT
 
 #include "type.ml"
 
@@ -25,5 +23,3 @@ end
 #undef INTLIT
 #undef FLOATLIT
 #undef STRINGLIT
-#undef TUPLE
-#undef VARIANT

--- a/lib/raw.cppo.mli
+++ b/lib/raw.cppo.mli
@@ -1,15 +1,11 @@
 (**
    Ints, floats and strings literals are systematically preserved using
    [`Intlit], [`Floatlit] and [`Stringlit].
-   This module also supports the specific syntax for variants and tuples
-   supported by {!Yojson.Safe}.
 *)
 
 #define INTLIT
 #define FLOATLIT
 #define STRINGLIT
-#define TUPLE
-#define VARIANT
 
 #include "type.ml"
 
@@ -29,5 +25,3 @@ end
 #undef INTLIT
 #undef FLOATLIT
 #undef STRINGLIT
-#undef TUPLE
-#undef VARIANT

--- a/lib/safe.cppo.ml
+++ b/lib/safe.cppo.ml
@@ -2,8 +2,6 @@
 #define INTLIT
 #define FLOAT
 #define STRING
-#define TUPLE
-#define VARIANT
 
 #include "type.ml"
 
@@ -29,5 +27,3 @@ end
 #undef INTLIT
 #undef FLOAT
 #undef STRING
-#undef TUPLE
-#undef VARIANT

--- a/lib/safe.cppo.mli
+++ b/lib/safe.cppo.mli
@@ -1,20 +1,17 @@
 (**
-   This module supports a specific syntax for variants and tuples
-   in addition to the standard JSON nodes.
+   This module supports a slight superset of the standard JSON nodes.
    Arbitrary integers are supported and represented as a decimal string 
    using [`Intlit] when they cannot be represented using OCaml's int type
    (31 or 63 bits depending on the platform).
 
-   This module is recommended for intensive use 
-   or OCaml-friendly use of JSON.
+   This module is recommended for intensive use or OCaml-friendly use of
+   JSON.
 *)
 
 #define INT
 #define INTLIT
 #define FLOAT
 #define STRING
-#define TUPLE
-#define VARIANT
 
 #include "type.ml"
 
@@ -37,5 +34,3 @@ end
 #undef INTLIT
 #undef FLOAT
 #undef STRING
-#undef TUPLE
-#undef VARIANT

--- a/lib/safe_to_basic.mli
+++ b/lib/safe_to_basic.mli
@@ -1,15 +1,9 @@
 val to_basic : t -> Basic.t
 (**
-     Tuples are converted to JSON arrays,
-     Variants are converted to JSON strings or arrays of a string (constructor)
-     and a json value (argument).
      Long integers are converted to JSON strings.
 
      Examples:
 {v
-`Tuple [ `Int 1; `Float 2.3 ]   ->    `List [ `Int 1; `Float 2.3 ]
-`Variant ("A", None)            ->    `String "A"
-`Variant ("B", Some x)          ->    `List [ `String "B", x ]
 `Intlit "12345678901234567890"  ->    `String "12345678901234567890"
 v}
   *)

--- a/lib/t.cppo.ml
+++ b/lib/t.cppo.ml
@@ -4,8 +4,6 @@
 #define FLOATLIT
 #define STRING
 #define STRINGLIT
-#define TUPLE
-#define VARIANT
 
 #include "type.ml"
 
@@ -25,5 +23,3 @@ end
 #undef FLOATLIT
 #undef STRING
 #undef STRINGLIT
-#undef TUPLE
-#undef VARIANT

--- a/lib/t.cppo.mli
+++ b/lib/t.cppo.mli
@@ -4,8 +4,6 @@
 #define FLOATLIT
 #define STRING
 #define STRINGLIT
-#define TUPLE
-#define VARIANT
 
 #include "type.ml"
 
@@ -21,5 +19,3 @@
 #undef FLOATLIT
 #undef STRING
 #undef STRINGLIT
-#undef TUPLE
-#undef VARIANT

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -15,8 +15,6 @@ let typeof = function
 #ifdef STRINGLIT
   | `Stringlit _ -> "stringlit"
 #endif
-  | `Tuple _ -> "tuple"
-  | `Variant _ -> "variant"
 
 let typerr msg js = raise (Type_error (msg ^ typeof js, js))
 

--- a/lib/write.mli
+++ b/lib/write.mli
@@ -14,7 +14,6 @@ val to_string :
       @param suf appended to the output as a suffix,
       defaults to empty string.
       @param std use only standard JSON syntax,
-      i.e. convert tuples and variants into standard JSON (if applicable),
       refuse to print NaN and infinities,
       require the root node to be either an object or an array.
       Default is [false].


### PR DESCRIPTION
Turns out in #158 I forgot to update a number of things, mostly issues that the compiler wouldn't warn about. This PR attempts to fix all the remaining bits that can be removed.