### PR TITLE
JSON5: fix escape sequences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 
+- Fixed handling of escape sequences in JSON5. Known escapes like \b will be
+  properly unescaped and undefined escape sequences will unescape to the
+  character itself as per spec (#187, @david-maison-TrustInSoft)
+
 ### Removed
 
 - Removed support for Tuple and Variant in JSON. It was a non-standard

--- a/lib/json5/unescape.ml
+++ b/lib/json5/unescape.ml
@@ -66,7 +66,13 @@ let unescape str =
           | None -> Error (Format.sprintf "bad escape sequence %s" escape_chars)
         in
         utf_8_string_of_unicode as_int
-    | 'b' | 'f' | 'n' | 'r' | 't' | 'v' -> Ok str
+    (* https://spec.json5.org/#escapes table 1 *)
+    | 'b' -> Ok "\b"
+    | 'n' -> Ok "\n"
+    | 'r' -> Ok "\r"
+    | 't' -> Ok "\t"
+    | 'f' -> Ok "\x0C"
+    | 'v' -> Ok "\x0B"
     | '0' ->
         if String.length str = 2 then Ok "\x00"
         else if String.length str = 4 then

--- a/lib/json5/unescape.ml
+++ b/lib/json5/unescape.ml
@@ -66,8 +66,7 @@ let unescape str =
           | None -> Error (Format.sprintf "bad escape sequence %s" escape_chars)
         in
         utf_8_string_of_unicode as_int
-    | '"' | '\'' | 'b' | 'f' | 'n' | 'r' | 't' | 'v' -> Ok str
-    | '\\' -> Ok {|\|}
+    | 'b' | 'f' | 'n' | 'r' | 't' | 'v' -> Ok str
     | '0' ->
         if String.length str = 2 then Ok "\x00"
         else if String.length str = 4 then
@@ -79,4 +78,14 @@ let unescape str =
           in
           utf_8_string_of_unicode as_int
         else Error (Format.sprintf "invalid octal sequence %s" str)
-    | _ -> Error (Format.sprintf "invalid escape sequence %c" str.[1])
+    | '1'..'9' ->
+      Error (Format.sprintf "invalid escape sequence %c" str.[1])
+    | c ->
+      (* According to https://spec.json5.org/#escapes : "If any other
+         character follows a reverse solidus, except for the decimal
+         digits 1 through 9, that character will be included in the
+         string, but the reverse solidus will not.".
+         Alternatively, apostrophe, quotation mark and reverse solidus
+         should also be included in the string without the leading
+         reverse solidus. *)
+      Ok (String.make 1 c)

--- a/lib/json5/unescape.ml
+++ b/lib/json5/unescape.ml
@@ -84,14 +84,13 @@ let unescape str =
           in
           utf_8_string_of_unicode as_int
         else Error (Format.sprintf "invalid octal sequence %s" str)
-    | '1'..'9' ->
-      Error (Format.sprintf "invalid escape sequence %c" str.[1])
+    | '1' .. '9' -> Error (Format.sprintf "invalid escape sequence %c" str.[1])
     | c ->
-      (* According to https://spec.json5.org/#escapes : "If any other
-         character follows a reverse solidus, except for the decimal
-         digits 1 through 9, that character will be included in the
-         string, but the reverse solidus will not.".
-         Alternatively, apostrophe, quotation mark and reverse solidus
-         should also be included in the string without the leading
-         reverse solidus. *)
-      Ok (String.make 1 c)
+        (* According to https://spec.json5.org/#escapes : "If any other
+           character follows a reverse solidus, except for the decimal
+           digits 1 through 9, that character will be included in the
+           string, but the reverse solidus will not.".
+           Alternatively, apostrophe, quotation mark and reverse solidus
+           should also be included in the string without the leading
+           reverse solidus. *)
+        Ok (String.make 1 c)

--- a/test_json5/test.ml
+++ b/test_json5/test.ml
@@ -41,6 +41,8 @@ let parsing_tests =
     parsing_should_succeed "more escaping quotes" {|'\"\''|} (`String {|"'|});
     parsing_should_succeed "escaping other chars" {|'\A\C\/\D\C'|}
       (`String "AC/DC");
+    parsing_should_succeed "built in escapes" {|'\b\n\r\t\f\v'|}
+      (`String "\b\n\r\t\012\011");
     parsing_should_succeed "null byte string" {|"\0"|} (`String "\x00");
     parsing_should_succeed "octal string" {|"\077"|} (`String "?");
     parsing_should_succeed "null and octal string" {|"\07"|} (`String "\x007");

--- a/test_json5/test.ml
+++ b/test_json5/test.ml
@@ -37,6 +37,10 @@ let parsing_tests =
     parsing_should_succeed "unicode escape sequence" {|"\u03bb"|} (`String "λ");
     parsing_should_succeed "more string escaping"
       "\"Hello \\u03bb \\x77\\x6F\\x72\\x6C\\x64\"" (`String "Hello λ world");
+    parsing_should_succeed "escaping quotes" {|"\"\'"|} (`String {|"'|});
+    parsing_should_succeed "more escaping quotes" {|'\"\''|} (`String {|"'|});
+    parsing_should_succeed "escaping other chars" {|'\A\C\/\D\C'|}
+      (`String "AC/DC");
     parsing_should_succeed "null byte string" {|"\0"|} (`String "\x00");
     parsing_should_succeed "octal string" {|"\077"|} (`String "?");
     parsing_should_succeed "null and octal string" {|"\07"|} (`String "\x007");


### PR DESCRIPTION
According to the specification https://spec.json5.org/#escapes , as far as I understand : 
- `\'` should be `'` in the returned string (not `\'`)
- `\"` should be `"` (not `\"`)
- and other characters should be returned without the leading backslash too (e.g., `\a` -> `a`)

However, I did not understand what happened for `\1` to `\9`, so I kept the former behavior: rejecting the escape sequence.
