### PR TITLE
Update image on which the actions are running

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,6 @@ on:
 jobs:
   Changelog-Entry-Check:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: tarides/changelog-check-action@v1

--- a/.github/workflows/pr-number.yml
+++ b/.github/workflows/pr-number.yml
@@ -2,7 +2,7 @@ name: PR number update
 on: [pull_request_target]
 jobs:
   PR-Number-Update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Update PR number
         uses: tarides/pr-number-action@v1.1


### PR DESCRIPTION
Ubuntu 20.04 was deprecated,
https://github.com/actions/runner-images/issues/11101 24.04 should be supported for some more time while working in hopefully the same way.