### PR TITLE
Update to new URL of ocaml-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Yojson: JSON library for OCaml
 ==============================
 
-[![Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focaml-community%2Fyojson%2Fmaster&logo=ocaml)](https://ci.ocamllabs.io/github/ocaml-community/yojson)
+[![Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Focaml.ci.dev%2Fbadge%2Focaml-community%2Fyojson%2Fmaster&logo=ocaml)](https://ocaml.ci.dev/github/ocaml-community/yojson)
 
 This library parses JSON data into a nested OCaml tree data structure.
 


### PR DESCRIPTION
Looks like the CI has changed URLs and the old ones are inaccessible.