### PR TITLE
Adds introductory example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ let json = Yojson.Safe.from_string json_string
 let () = Format.printf "Parsed to %a" Yojson.Safe.pp json
 ```
 
+The `examples` directory contains more.
 
 Related tooling
 ---------------

--- a/examples/dune
+++ b/examples/dune
@@ -9,9 +9,9 @@
  (libraries yojson))
 
 (executable
-  (name introduction)
-  (modules introduction)
-  (libraries yojson))
+ (name introduction)
+ (modules introduction)
+ (libraries yojson))
 
 (alias
  (name examples)

--- a/examples/dune
+++ b/examples/dune
@@ -8,6 +8,11 @@
  (modules constructing)
  (libraries yojson))
 
+(executable
+  (name introduction)
+  (modules introduction)
+  (libraries yojson))
+
 (alias
  (name examples)
  (deps filtering.exe))

--- a/examples/introduction.json
+++ b/examples/introduction.json
@@ -1,0 +1,3 @@
+{"Number" : 1,
+ "String" : "two",
+ "List": ["containing", "different", "types", 35.4]}

--- a/examples/introduction.ml
+++ b/examples/introduction.ml
@@ -7,10 +7,11 @@ let json_string =
 (* Print as parse tree *)
 let print_parse_tree () =
   Format.printf "%a\n" Yojson.Safe.pp (Yojson.Safe.from_string json_string)
-  
+
 (* Print as JSON *)
 let prettyprint () =
-  Printf.printf "%s\n" (Yojson.Safe.pretty_to_string (Yojson.Safe.from_string json_string))
+  Printf.printf "%s\n"
+    (Yojson.Safe.pretty_to_string (Yojson.Safe.from_string json_string))
 
 (* Read some JSON from a file, add up all numbers, and print. *)
 let sum_floats = List.fold_left ( +. ) 0.
@@ -22,7 +23,7 @@ let rec sum_json : Yojson.Safe.t -> float = function
   | `List l -> sum_floats (List.map sum_json l)
   | `Assoc l -> sum_floats (List.map sum_json (List.map snd l))
   | _ -> failwith "unexpected construct in sum_json"
-  
+
 let sum filename =
   Printf.printf "%f\n" (sum_json (Yojson.Safe.from_file filename))
 
@@ -35,18 +36,18 @@ let rec reverse_json = function
 let reverse in_filename out_filename =
   let json = reverse_json (Yojson.Safe.from_file in_filename) in
   let fh = open_out_bin out_filename in
-    Yojson.Safe.pretty_to_channel fh json;
-    close_out fh
+  Yojson.Safe.pretty_to_channel fh json;
+  close_out fh
 
 (* You can use the file introduction.json as an example input for the "sum" and
    "reverse" examples. *)
 let () =
   match Sys.argv with
-  | [|_; "print_parse_tree"|] -> print_parse_tree ()
-  | [|_; "prettyprint"|] -> prettyprint ()
-  | [|_; "sum"; filename|] -> sum filename
-  | [|_; "reverse"; in_filename; out_filename|] -> reverse in_filename out_filename
+  | [| _; "print_parse_tree" |] -> print_parse_tree ()
+  | [| _; "prettyprint" |] -> prettyprint ()
+  | [| _; "sum"; filename |] -> sum filename
+  | [| _; "reverse"; in_filename; out_filename |] ->
+      reverse in_filename out_filename
   | _ ->
-      Printf.eprintf
-        "%s: unknown command line\n"
+      Printf.eprintf "%s: unknown command line\n"
         (if Array.length Sys.argv > 0 then Sys.argv.(0) else "")

--- a/examples/introduction.ml
+++ b/examples/introduction.ml
@@ -1,0 +1,57 @@
+(* Get a file as a string *)
+let contents_of_file filename =
+  let ch = open_in_bin filename in
+    try
+      let s = really_input_string ch (in_channel_length ch) in
+        close_in ch;
+        s
+    with
+      e -> close_in ch; raise e
+
+(* JSON inline as a string *)
+let json_string =
+  {|{"Number" : 1,
+     "String" : "two",
+     "List": ["containing", "different", "types", 35.4]}|}
+
+(* Print as parse tree *)
+let print_parse_tree () =
+  Format.printf "%a\n" Yojson.Safe.pp (Yojson.Safe.from_string json_string)
+  
+(* Print as JSON *)
+let prettyprint () =
+  Printf.printf "%s\n" (Yojson.Safe.pretty_to_string (Yojson.Safe.from_string json_string))
+
+(* Read some JSON from a file, add up all numbers, and print. *)
+let sum_floats = List.fold_left ( +. ) 0.
+
+let rec sum_json : Yojson.Safe.t -> float = function
+  | `Float f -> f
+  | `Int i -> float_of_int i
+  | `String _ -> 0.
+  | `List l -> sum_floats (List.map sum_json l)
+  | `Assoc l -> sum_floats (List.map sum_json (List.map snd l))
+  | _ -> failwith "unexpected construct in sum_json"
+  
+let sum filename =
+  Printf.printf "%f\n" (sum_json (Yojson.Safe.from_string (contents_of_file filename)))
+
+(* Read some JSON from a file, reverse any lists in it, and write to file. *)
+let rec reverse_json = function
+  | `List l -> `List (List.rev (List.map reverse_json l))
+  | `Assoc l -> `Assoc (List.map (fun (k, v) -> (k, reverse_json v)) l)
+  | x -> x
+
+let reverse in_filename out_filename =
+  let json = reverse_json (Yojson.Safe.from_string (contents_of_file in_filename)) in
+  let fh = open_out out_filename in
+    output_string fh (Yojson.Safe.pretty_to_string json);
+    close_out fh
+
+let () =
+  match Sys.argv with
+  | [|_; "print_parse_tree"|] -> print_parse_tree ()
+  | [|_; "prettyprint"|] -> prettyprint ()
+  | [|_; "sum"; filename|] -> sum filename
+  | [|_; "reverse"; in_filename; out_filename|] -> reverse in_filename out_filename
+  | _ -> Printf.eprintf "yojson_example: unknown command line\n"


### PR DESCRIPTION
Hello!

This pull request adds an introductory example to YoJSON. This is part of a pilot programme funded by the OCaml Software Foundation.

Many OCaml libraries have no examples, or perfunctory examples only. This makes it difficult to get started with a library, particularly if it has an elaborate interface. A working example, no matter how small, can help a newcomer get started quickly. One day, it would be nice to have an example for every Opam package.

For now, examples begin in the OCaml Nursery, here: https://github.com/johnwhitington/ocaml-nursery  (you can read in the README there about the principles behind these examples.) Then, if package authors agree, they are promoted to upstream source. The hope is that this will mean they are more likely to be kept up to date with the library.

The examples are usually, included in a separate directory, within a separate Dune workspace. And so they are intended to be used after installation of the library. However, in this case, I have followed the pattern of the existing examples.

As well as considering accepting this pull request, please do give any comments you have on this programme.